### PR TITLE
Remove VHBB, replace reF00D with 0syscall6

### DIFF
--- a/_pages/en_US/finalizing-setup.txt
+++ b/_pages/en_US/finalizing-setup.txt
@@ -10,7 +10,7 @@ We will now setup applications and plugins such as the following:
 
 +  **Vita Homebrew Browser** *(downloads and installs other homebrew applications)*
 +  **NoNpDrm** *(allows for encrypted games and applications to be used)*
-+  **reF00D** *(allows for transparently decrypting games and applications of any firmware version)*
++  **0syscall6** *(allows using games and applications that require higher firmware versions)*
 +  **DownloadEnabler** *(allows any file type to be downloaded with the browser)*
 +  **shellbat** *(displays exact battery percentage in the status bar)*
 +  **pngshot** *(improves the built-in screenshot utility)*
@@ -23,11 +23,9 @@ We will also block updates using a DNS server. The server tricks your device int
 
 * An FTP Client such as [WinSCP](https://winscp.net/) or [CyberDuck](https://cyberduck.io/)
   + Alternatively, you can also use the USB transfer feature of VitaShell
-* <i class="fa fa-magnet" aria-hidden="true" title="This is a magnet link. Use a torrent client to download the file."></i> - [keys.bin](magnet:?xt=urn:btih:a3796f22b82b80c5fefa8407c6fd7d71df2c2258&dn=keys.bin&tr=udp%3A%2F%2Ftracker.coppersurfer.tk%3A6969%2Fannounce&tr=udp%3A%2F%2Ftracker.internetwarriors.net%3A1337%2Fannounce&tr=udp%3A%2F%2Ftracker.opentrackr.org%3A1337%2Fannounce&tr=udp%3A%2F%2F9.rarbg.to%3A2710%2Fannounce&tr=udp%3A%2F%2Fexodus.desync.com%3A6969%2Fannounce&tr=http%3A%2F%2Ftracker3.itzmx.com%3A6961%2Fannounce&tr=udp%3A%2F%2Fexplodie.org%3A6969%2Fannounce&tr=udp%3A%2F%2Ftracker.tiny-vps.com%3A6969%2Fannounce&tr=udp%3A%2F%2Fthetracker.org%3A80%2Fannounce&tr=udp%3A%2F%2Fipv4.tracker.harry.lu%3A80%2Fannounce&tr=udp%3A%2F%2Fdenis.stalker.upeer.me%3A6969%2Fannounce&tr=udp%3A%2F%2Ftracker1.itzmx.com%3A8080%2Fannounce&tr=udp%3A%2F%2Ftracker.torrent.eu.org%3A451%2Fannounce&tr=udp%3A%2F%2Ftracker.cyberia.is%3A6969%2Fannounce&tr=udp%3A%2F%2Fopen.stealth.si%3A80%2Fannounce&tr=udp%3A%2F%2Fopen.demonii.si%3A1337%2Fannounce&tr=udp%3A%2F%2Fbt.xxx-tracker.com%3A2710%2Fannounce&tr=http%3A%2F%2Ftracker4.itzmx.com%3A2710%2Fannounce&tr=udp%3A%2F%2Ftracker1.wasabii.com.tw%3A6969%2Fannounce&tr=udp%3A%2F%2Ftracker.port443.xyz%3A6969%2Fannounce) ([mirror](https://www.mediafire.com/download/t5obgaa3naatr9m))
 * [config.txt]({{ "/assets/files/config.txt" | absolute_url }}){:download="config.txt"}
-* The latest release of [Vita Homebrew Browser](https://github.com/devnoname120/vhbb/releases/latest)
 * The latest release of [NoNpDrm](https://github.com/TheOfficialFloW/NoNpDrm/releases/latest)
-* The latest release of [reF00D](https://github.com/dots-tb/reF00D/releases/latest)
+* The latest release of [0syscall6](https://github.com/SKGleba/0syscall6/releases/latest)
 * The latest release of [DownloadEnabler](https://github.com/TheOfficialFloW/VitaTweaks/releases/tag/DownloadEnabler)
 * The latest release of [shellbat](https://github.com/nowrep/vita-shellbat/releases/latest)
 * The latest release of [pngshot](https://github.com/xyzz/pngshot/releases/latest)
@@ -56,24 +54,13 @@ We will also block updates using a DNS server. The server tricks your device int
 1. Transfer `config.txt` to  the `tai` folder
   + Overwrite (replace) the existing `config.txt` file
 1. Transfer `nonpdrm.skprx` to the `tai` folder
-1. Transfer `reF00D.skprx` to the `tai` folder
-1. Transfer `keys.bin` to the `tai` folder
+1. Transfer `0syscall6.skprx` to the `tai` folder
 1. Transfer `download_enabler.suprx` to the `tai` folder
 1. Transfer `shellbat.suprx` to the `tai` folder
 1. Transfer `pngshot.suprx` to the `tai` folder
 1. Press (Circle) on your device to close the FTP connection
 
-#### Section II - Installing VPKs
-
-1. On your device, navigate to `ux0:` -> `data/`
-1. Press (Cross) on `VitaHBBrowser.vpk` to install it
-1. Press (Cross) to confirm the install
-1. Press (Cross) to continue the install if you are prompted about extended permissions
-1. Press (Triangle) to open the menu, then select "Delete" to delete the `.vpk` file
-1. Press (Cross) to confirm the deletion
-1. Close the VitaShell application
-
-#### Section III - Blocking Updates
+#### Section II - Blocking Updates
 
 1. Launch the Settings application
 1. Navigate to `Network` -> `Wi-Fi Settings`
@@ -88,7 +75,7 @@ We will also block updates using a DNS server. The server tricks your device int
 1. Ensure "Proxy Server" is set to "Do Not Use"
 1. Close the Settings application
 
-#### Section IV - PSN Access
+#### Section III - PSN Access
 
 1. Launch the Settings application
 1. Navigate to `HENkaku Settings`
@@ -99,7 +86,7 @@ We will also block updates using a DNS server. The server tricks your device int
   + Should a new firmware version be released in the future, you must change the spoofed version to match in order to access PSN
 1. Close the Settings application
 
-#### Section V - Cleanup
+#### Section IV - Cleanup
 
 1. Launch the Content Manager application
 1. Select "Manage Content on Memory Card"
@@ -114,7 +101,7 @@ We will also block updates using a DNS server. The server tricks your device int
 
 ___
 
-You can now easily install new homebrew applications just by using Vita Homebrew Browser. Alternatively, you can also browse for new homebrew applications on [VitaDB](https://vitadb.rinnegatamante.it/).
+You can browse for new homebrew applications on [VitaDB](https://vitadb.rinnegatamante.it/).
 {: .notice--info}
 
 It is *not* recommended to make modifications to your Custom Firmware installation by installing homebrew applications intended for advanced users (such as "Enso EX"). Doing so without fully understanding the system can lead to a BRICK!

--- a/assets/files/config.txt
+++ b/assets/files/config.txt
@@ -4,7 +4,7 @@
 
 *KERNEL
 ur0:tai/nonpdrm.skprx
-ur0:tai/reF00D.skprx
+ur0:tai/0syscall6.skprx
 
 *main
 ur0:tai/henkaku.suprx


### PR DESCRIPTION
The Vita Homebrew Browser has not worked in a while, it may never work again. VitaDB with the Download Enabler is a fine replacement, and those are both already mentioned/installed in the guide. reF00D's Github page tells users to use 0syscall6, which has benefits like launching games slightly faster and not requiring the keys.bin.