### PR TITLE
Fix and clarification.

### DIFF
--- a/_pages/en_US/adrenaline.txt
+++ b/_pages/en_US/adrenaline.txt
@@ -47,7 +47,7 @@ You must have already installed VitaShell to use this.
 
 1. Press (Circle) to return to `ux0:`
 1. Navigate to `tai/`
-  + If `urx:tai` doesn't exist, press (Circle) again and then navigate to `ur0:tai`
+  + If `ux0:tai` doesn't exist, press (Circle) again and then navigate to `ur0:tai`
 1. Press (Cross) on `config.txt` to open it in the editor
 1. Highlight the `*KERNEL` line with the cursor
 1. Press (Triangle) to open the menu, then select "Insert empty line"

--- a/_pages/en_US/installing-henkaku.txt
+++ b/_pages/en_US/installing-henkaku.txt
@@ -29,7 +29,7 @@ If you have a PS Vita 1000, you must also have an official Sony memory card (of 
 1. Read the disclaimer, then tap "Install"
   + If you get an error and cannot proceed, [follow this troubleshooting guide](troubleshooting#a-browser-based-exploit-is-not-working)
 1. If the exploit was successful, you will now have a bubble on your LiveArea screen named "molecularShell".
-  + If the exploit was successful but the molecularShell application is missing, perform the exploit again and press R1 when prompted to re-install molecularShell
+  + If the exploit was successful but the molecularShell application is missing, perform the exploit again and press R1 when prompted to re-install molecularShell. (Note : If you have just downgraded and have vitashell in your memorycard, henkaku won't install molecularshell because it will detect an already existing taihen config. This is not a problem because molecularshell is just an outdated version of vitashell. So keep using vitashell.)
 
 #### Section II - Configuring HENkaku
 

--- a/_pages/en_US/storage-format-(mac).txt
+++ b/_pages/en_US/storage-format-(mac).txt
@@ -26,7 +26,7 @@ This page is for Mac users only. If you are not on Mac, check out the [Storage F
 1. Run `diskutil unmount /dev/disk2   sudo dd if=/dev/zero of=/dev/disk2` to clean the microsd (change disk2 by your disk number)
 1. Remove and reinsert your storage device
 1. Run `sudo newfs_exfat -R /dev/disk2` to format your storage device into exfat
-  + If your storage device has a capacity of 256 GB or greater, you must run `sudo newfs_exfat -R  -c 128 /dev/disk2` (It will format with a cluster size of 64kb)
+  + If your storage device has a capacity of 256 GB or greater, you must run `sudo newfs_exfat -R  -c 64 /dev/disk2` 
   
 #### Section II - Verifying Storage Device
 

--- a/_pages/en_US/storage-format-(mac).txt
+++ b/_pages/en_US/storage-format-(mac).txt
@@ -22,12 +22,12 @@ This page is for Mac users only. If you are not on Mac, check out the [Storage F
 #### Section I - Formatting Storage Device
 
 1. Insert your storage device into your computer
-1. Launch Disk Utility
-1. Select your storage device
-1. Select the "Partition" menu
-1. Partition your storage device as MBR with one exFAT partition
-  + If your storage device has a capacity of 256 GB or greater, you must format with a cluster size of 64 KB
-
+1. Open a terminal an run `diskutil list` to know which disk corresponds to your storage device (usually /dev/disk2)
+1. Run `diskutil unmount /dev/disk2   sudo dd if=/dev/zero of=/dev/disk2` to clean the microsd (change disk2 by your disk number)
+1. Remove and reinsert your storage device
+1. Run `sudo newfs_exfat -R /dev/disk2` to format your storage device into exfat
+  + If your storage device has a capacity of 256 GB or greater, you must run `sudo newfs_exfat -R  -c 128 /dev/disk2` (It will format with a cluster size of 64kb)
+  
 #### Section II - Verifying Storage Device
 
 If you do not want to check your storage device for errors, skip this section.

--- a/_pages/en_US/storagemgr.txt
+++ b/_pages/en_US/storagemgr.txt
@@ -48,6 +48,8 @@ You must have already installed VitaShell to use this.
 1. Add the following line to `ur0:tai/config.txt` under the `*KERNEL` line:
   + `ur0:tai/storagemgr.skprx`
 1. Delete the `ux0:tai/` folder
+
+This is an important step as henkaku will not load plugins installed in ur0:tai if it detects that ux0:tai exist.
   
 #### Section II - Restoring Data
 


### PR DESCRIPTION
1 Explained why users who downgraded from 3.60 up doesn't have molecularshell when installing henkaku (and why they shouldn't care)
2 Added the explanation for why we delete ux0:tai
3 Fixed mac storage part which was not accurate in vita case