### PR TITLE
Various changes

### DIFF
--- a/_pages/en_US/blocking-updates.txt
+++ b/_pages/en_US/blocking-updates.txt
@@ -6,30 +6,16 @@ title: "Blocking Updates"
 
 ### Required Reading
 
-To prevent unwanted updates, we configure the device's DNS settings to use a custom update server which points to 3.60 as the latest update available. This has the effect of blocking any firmware versions above 3.60 from being installed when the device attempts to perform an update.
-
+To prevent unwanted updates, we will disable an option made by sony which automatically download the update file from their servers on your vita.
 ### What you need
 
 * An internet connection on your PS Vita (TV)
 
 ### Instructions
 
-#### Section I - DNS Configuration
+#### Section I - Disabling the auto-download option
 
-Note that these DNS servers will need to be set on each network you connect your device to for it to block updates!
-{: .notice--warning}
 
-1. Launch the Settings application
-1. Navigate to `Network` -> `Wi-Fi Settings`
-  + Connect to a Wi-Fi network if you have not already done so
-1. Select your current connection
-  + This is signified by a green dot next to the network
-1. Select "Advanced Settings"
-1. Set "DNS Settings" to "Manual"
-1. Set "Primary DNS" to `212.47.229.76`
-1. Leave "Secondary DNS" blank
-1. Ensure "Proxy Server" is set to "Do Not Use"
-1. Return to the main Settings menu
 1. Navigate to `System` -> `Auto-Start Settings`
 1. Uncheck "Download Update File for System Software"
 1. Return to the main Settings menu

--- a/_pages/en_US/faq.txt
+++ b/_pages/en_US/faq.txt
@@ -9,8 +9,7 @@ title: "FAQ"
 **A:** Yes, the tool Modoru can downgrade any system hacked with HENkaku or h-encore to any firmware equal or greater than the firmware the console came with out of the box.
 
 <a name="faq_update" />**Q:** *Is it safe to update a Vita with CFW?*
-**A:** No! You must always ensure that you have blocked updates as specified at the end of [Finalizing Setup](finalizing-setup).
-
+**A:** There is no need to update a PSVita with CFW. Stay in 3.60 (or 3.65 if you couldn't downgrade lower)
 <a name="faq_risky" />**Q:** *How risky is hacking my console?*
 **A:** Bricks are *basically* impossible unless you ignore instructions.
 
@@ -21,4 +20,4 @@ title: "FAQ"
 **A:** For support, ask for help at [Vita Hacking on Discord](https://discord.gg/JXEKeg6).
 
 <a name="faq_nopc" />**Q:** *Can I do this without a computer?*
-**A:** No, you must have a PC to complete this guide.
+**A:** No, you must have a PC to complete this guide. Unless you are on 3.60 already

--- a/_pages/en_US/faq.txt
+++ b/_pages/en_US/faq.txt
@@ -21,4 +21,4 @@ title: "FAQ"
 **A:** For support, ask for help at [Official Henkaku Discord](https://discord.gg/m7MwpKA).
 
 <a name="faq_nopc" />**Q:** *Can I do this without a computer?*
-**A:** No, you must have a PC to complete this guide. Unless you are on 3.60 already
+**A:** You must have a computer if you are on firmware version 3.61 or higher.

--- a/_pages/en_US/faq.txt
+++ b/_pages/en_US/faq.txt
@@ -17,7 +17,7 @@ title: "FAQ"
 **A:** Yes! This enables any custom user-made homebrew to be played on your device.
 
 <a name="faq_support" />**Q:** *Where should I go for support?*
-**A:** For support, ask for help at [Vita Hacking on Discord](https://discord.gg/JXEKeg6).
+**A:** For support, ask for help at [Official Henkaku Discord](https://discord.gg/m7MwpKA).
 
 <a name="faq_nopc" />**Q:** *Can I do this without a computer?*
 **A:** No, you must have a PC to complete this guide. Unless you are on 3.60 already

--- a/_pages/en_US/faq.txt
+++ b/_pages/en_US/faq.txt
@@ -9,7 +9,8 @@ title: "FAQ"
 **A:** Yes, the tool Modoru can downgrade any system hacked with HENkaku or h-encore to any firmware equal or greater than the firmware the console came with out of the box.
 
 <a name="faq_update" />**Q:** *Is it safe to update a Vita with CFW?*
-**A:** There is no need to update a PSVita with CFW. Stay in 3.60 (or 3.65 if you couldn't downgrade lower)
+**A:** There is no need to update a PSVita with CFW. Stay on 3.60 or 3.65.
+
 <a name="faq_risky" />**Q:** *How risky is hacking my console?*
 **A:** Bricks are *basically* impossible unless you ignore instructions.
 

--- a/_pages/en_US/finalizing-setup.txt
+++ b/_pages/en_US/finalizing-setup.txt
@@ -57,6 +57,7 @@ In order to install the necessary `.vpk` (content package) file on your device, 
 1. Transfer `pngshot.suprx` to the `tai` folder
 1. Transfer `PSVshell.skprx` to the `tai` folder
 1. Press (Circle) on your device to close the FTP connection
+  + Additionally if you want to learn how to install plugins on your vita and understand the config.txt you can read [this](https://samilops2.gitbook.io/vita-troubleshooting-guide/plugins-related-problem/error-when-using-autoplugin)
 
 #### Section II - Blocking Updates
 

--- a/_pages/en_US/finalizing-setup.txt
+++ b/_pages/en_US/finalizing-setup.txt
@@ -86,7 +86,8 @@ In order to install the necessary `.vpk` (content package) file on your device, 
   + "modoru 戻る"
   + "molecularShell"
 1. Users on firmware version 3.60 should additionally delete the following application if it exists:
-  + "h-encore" (Launching h-encore on 3.60 will make the PSVita reboot, the exploit is not working for 3.60 so don't use it)
+  + "h-encore"
+    + the h-encore exploit will not work on 3.60 and the device will reboot if used
 1. Close the Content Manager application
 
 ___

--- a/_pages/en_US/finalizing-setup.txt
+++ b/_pages/en_US/finalizing-setup.txt
@@ -57,7 +57,7 @@ In order to install the necessary `.vpk` (content package) file on your device, 
 1. Transfer `pngshot.suprx` to the `tai` folder
 1. Transfer `PSVshell.skprx` to the `tai` folder
 1. Press (Circle) on your device to close the FTP connection
-  + Additionally if you want to learn how to install plugins on your vita and understand the config.txt you can read [this](https://samilops2.gitbook.io/vita-troubleshooting-guide/plugins-related-problem/error-when-using-autoplugin)
+  + For more information on plugins and their installation, read [this webpage](https://samilops2.gitbook.io/vita-troubleshooting-guide/plugins-related-problem/error-when-using-autoplugin)
 
 #### Section II - Blocking Updates
 

--- a/_pages/en_US/finalizing-setup.txt
+++ b/_pages/en_US/finalizing-setup.txt
@@ -13,10 +13,9 @@ We will now setup applications and plugins such as the following:
 +  **DownloadEnabler** *(allows any file type to be downloaded with the browser)*
 +  **shellbat** *(displays exact battery percentage in the status bar)*
 +  **pngshot** *(improves the built-in screenshot utility)*
++  **PSVshell** *(allows overclocking the PSVita for better performances as well as showing cpu usage and fps counter)*
 
 In order to install the necessary `.vpk` (content package) file on your device, we use the [File Transfer Protocol (FTP)](https://wikipedia.org/wiki/File_Transfer_Protocol) to copy the files to your device's memory card.
-
-We will also block updates using a DNS server. The server tricks your device into detecting 3.60 as the latest firmware version, meaning it won't update past that. This is useful because 3.60 is the earliest firmware that HENkaku works on. These settings must be applied to every network that you join.
 
 ### What You Need
 
@@ -28,6 +27,7 @@ We will also block updates using a DNS server. The server tricks your device int
 * The latest release of [DownloadEnabler](https://github.com/TheOfficialFloW/VitaTweaks/releases/tag/DownloadEnabler)
 * The latest release of [shellbat](https://github.com/nowrep/vita-shellbat/releases/latest)
 * The latest release of [pngshot](https://github.com/xyzz/pngshot/releases/latest)
+* The latest release of [PSVshell](https://github.com/Electry/PSVshell)
 
 ### Instructions
 
@@ -55,21 +55,14 @@ We will also block updates using a DNS server. The server tricks your device int
 1. Transfer `download_enabler.suprx` to the `tai` folder
 1. Transfer `shellbat.suprx` to the `tai` folder
 1. Transfer `pngshot.suprx` to the `tai` folder
+1. Transfer `PSVshell.skprx` to the `tai` folder
 1. Press (Circle) on your device to close the FTP connection
 
 #### Section II - Blocking Updates
 
 1. Launch the Settings application
-1. Navigate to `Network` -> `Wi-Fi Settings`
-  + Connect to a Wi-Fi network if you have not already done so
-1. Select your current connection
-  + This is signified by a green dot next to the network
-1. Select "Advanced Settings"
-1. Set "DNS Settings" to "Manual"
-  + You must apply the following DNS settings to each network you use
-1. Set "Primary DNS" to `212.47.229.76`
-1. Set "Secondary DNS" to `212.47.229.76`
-1. Ensure "Proxy Server" is set to "Do Not Use"
+1. Navigate to `System` -> `Auto-Start Settings`
+1. Uncheck the `Download Update File for System Sofwtare`
 1. Close the Settings application
 
 #### Section III - PSN Access
@@ -89,11 +82,10 @@ We will also block updates using a DNS server. The server tricks your device int
 1. Select "Manage Content on Memory Card"
 1. Select "PS Vita"
 1. Delete the following applications if they exist (note that, depending on your install method, some or all of these applications may be missing):
-  + "ensō"
   + "modoru 戻る"
   + "molecularShell"
 1. Users on firmware version 3.60 should additionally delete the following application if it exists:
-  + "h-encore"
+  + "h-encore" (Launching h-encore on 3.60 will make the PSVita reboot, the exploit is not working for 3.60 so don't use it)
 1. Close the Content Manager application
 
 ___

--- a/_pages/en_US/installing-h-encore.txt
+++ b/_pages/en_US/installing-h-encore.txt
@@ -77,7 +77,11 @@ h-encore² only has a ~25% success rate. It may take a long time to launch the h
   + This will install the HENkaku exploit and enable homebrew access until the next reboot
 1. Select "Exit"
 
-Note : The "Download VitaShell" is not working for the moment due to a bug with github interactions with the PSVita, VitaShell (and all homebrew applications in general) will remain installed after a reboot, but will give an error on launch if the HENkaku exploit is not active
+Homebrew applications such as VitaShell will remain installed after a reboot, however will give an error on launch until the exploit is applied.
+{: .notice--info}
+
+Due to a bug concerning the PSVita interacting with GitHub, the "Download VitaShell" option is not working for the time being. 
+{: .notice--warning}
 
 #### Section IV - Configuring HENkaku
 

--- a/_pages/en_US/installing-h-encore.txt
+++ b/_pages/en_US/installing-h-encore.txt
@@ -27,7 +27,9 @@ If you have a PS Vita 1000, you must also have an official Sony memory card (of 
 
 #### Section I - finalhe
 
-1. Copy the contents of the finalhe `.zip` to a folder on your computer and place the vitashell zip in the same folder (do not extract it)
+1. Copy the contents of the finalhe `.zip` file to a folder on your computer
+1. Copy the VitaShell `.zip` file inside the finalhe folder
+  + Do not extract this file
 1. Launch finalhe on your computer
   + If you are prompted to allow finalhe network access through the firewall, do so
 1. Launch the Content Manager application on your device
@@ -52,7 +54,8 @@ If you have a PS Vita 1000, you must also have an official Sony memory card (of 
 1. Select "PC -> PS Vita System" on your device
 1. Select "Applications"
 1. Select "PS Vita"
-1. Select "h-encore" or "h-encore²" depending on which is displayed, and vitashell
+1. Select "h-encore" or "h-encore²" depending on which is displayed
+1. Select "VitaShell"
 1. Select "Copy"
 1. Select "OK"
   + The h-encore exploit will be copied to your device

--- a/_pages/en_US/installing-h-encore.txt
+++ b/_pages/en_US/installing-h-encore.txt
@@ -21,7 +21,7 @@ If you have a PS Vita 1000, you must also have an official Sony memory card (of 
 
 * The latest release of [finalhe](https://github.com/soarqin/finalhe/releases/latest)
   - If you are using MacOS or Linux you will be required to compile finalhe yourself
-* The zip file of [Vitashell](https://github.com/soarqin/finalhe/releases/download/v1.91/app_VitaShell-2.0.zip) file manager for the PSVita
+* The [Vitashell](https://github.com/soarqin/finalhe/releases/download/v1.91/app_VitaShell-2.0.zip) file manager for the PSVita
 
 ### Instructions
 

--- a/_pages/en_US/installing-h-encore.txt
+++ b/_pages/en_US/installing-h-encore.txt
@@ -21,12 +21,13 @@ If you have a PS Vita 1000, you must also have an official Sony memory card (of 
 
 * The latest release of [finalhe](https://github.com/soarqin/finalhe/releases/latest)
   - If you are using MacOS or Linux you will be required to compile finalhe yourself
+* The zip file of [Vitashell](https://github.com/soarqin/finalhe/releases/download/v1.91/app_VitaShell-2.0.zip) file manager for the PSVita
 
 ### Instructions
 
 #### Section I - finalhe
 
-1. Copy the contents of the finalhe `.zip` to a folder on your computer
+1. Copy the contents of the finalhe `.zip` to a folder on your computer and place the vitashell zip in the same folder (do not extract it)
 1. Launch finalhe on your computer
   + If you are prompted to allow finalhe network access through the firewall, do so
 1. Launch the Content Manager application on your device
@@ -51,7 +52,7 @@ If you have a PS Vita 1000, you must also have an official Sony memory card (of 
 1. Select "PC -> PS Vita System" on your device
 1. Select "Applications"
 1. Select "PS Vita"
-1. Select "h-encore" or "h-encore²" depending on which is displayed
+1. Select "h-encore" or "h-encore²" depending on which is displayed, and vitashell
 1. Select "Copy"
 1. Select "OK"
   + The h-encore exploit will be copied to your device
@@ -71,10 +72,9 @@ h-encore² only has a ~25% success rate. It may take a long time to launch the h
   + If it is still stuck, hold the power button down for over 30 seconds to force a reboot, then try again
 1. Select "Install HENkaku"
   + This will install the HENkaku exploit and enable homebrew access until the next reboot
-1. Select "Download VitaShell"
-  + This will install the VitaShell homebrew application for managing your device's filesystem
-  + VitaShell (and all homebrew applications in general) will remain installed after a reboot, but will give an error on launch if the HENkaku exploit is not active
 1. Select "Exit"
+
+Note : The "Download VitaShell" is not working for the moment due to a bug with github interactions with the PSVita, VitaShell (and all homebrew applications in general) will remain installed after a reboot, but will give an error on launch if the HENkaku exploit is not active
 
 #### Section IV - Configuring HENkaku
 

--- a/_pages/en_US/troubleshooting.txt
+++ b/_pages/en_US/troubleshooting.txt
@@ -25,10 +25,11 @@ Browser based exploits (such as the WebKit exploit used for HENkaku) can be unst
 1. Go to your [PSN Account Management Page](https://account.sonyentertainmentnetwork.com/home/index!display.action)
 1. Under the devices section, choose "PlayStation Systems"
 1. Select your console
-1. Select "Desactivate"
+1. Select "Deactivate"
 
 ## Black screen on boot
 
 1. Hold L on boot to disable TaiHEN plugin loading
 1. If your device boots, try editing `ux0:tai/config.txt` and remove any plugins you may have recently added
-1. If these instructions do not work, your device may be bricked. you will need to follow this [tutorial](https://samilops2.gitbook.io/vita-troubleshooting-guide/serious-problems/bootloop)
+1. If these instructions do not work, your device may be bricked
+  + In unlikely event of this happening, please follow [this tutorial](https://samilops2.gitbook.io/vita-troubleshooting-guide/serious-problems/bootloop)

--- a/_pages/en_US/troubleshooting.txt
+++ b/_pages/en_US/troubleshooting.txt
@@ -18,16 +18,17 @@ Browser based exploits (such as the WebKit exploit used for HENkaku) can be unst
 1. Launch the browser, then open the browser settings
 1. Scroll to the bottom and click "Delete Cookies" and "Clear Search History"
 1. Try the exploit again
+  + If it still doesn't work, try to reboot, wait 5 minute, and open the browser
 
 ## Removing an PSN account without formatting your device
 
 1. Go to your [PSN Account Management Page](https://account.sonyentertainmentnetwork.com/home/index!display.action)
 1. Under the devices section, choose "PlayStation Systems"
 1. Select your console
-1. Select "Deactivate"
+1. Select "Desactivate"
 
 ## Black screen on boot
 
 1. Hold L on boot to disable TaiHEN plugin loading
 1. If your device boots, try editing `ux0:tai/config.txt` and remove any plugins you may have recently added
-1. If these instructions do not work, your device may be bricked
+1. If these instructions do not work, your device may be bricked. you will need to follow this [tutorial](https://samilops2.gitbook.io/vita-troubleshooting-guide/serious-problems/bootloop)

--- a/assets/files/config.txt
+++ b/assets/files/config.txt
@@ -5,6 +5,7 @@
 *KERNEL
 ur0:tai/nonpdrm.skprx
 ur0:tai/0syscall6.skprx
+ur0:tai/PSVshell.skprx
 
 *main
 ur0:tai/henkaku.suprx


### PR DESCRIPTION
1 added a way to install vitashell on psvita without using the hencore option as it is currently not working anymore
2 various enhancement
3 changed vita hacking discord to official henkaku server as it is the best place to get help with an active helper team and developers presence 
4 added PSVshell in the finalizing setup
5 removed the dns as we don't need it (and not working correctly lately) and can cause network issues. 
