### PR TITLE
Added Info about Samsung Evos.

### DIFF
--- a/_pages/en_US/yamt.txt
+++ b/_pages/en_US/yamt.txt
@@ -16,6 +16,9 @@ This will use FTP (File Transfer Protocol) to transfer the files, so your Vita a
 If you're using a USB drive or psvsd adapter, or if this method doesn't work for you, follow the [StorageMgr](storagemgr) guide.
 {: .notice--primary}
 
+Samsung Evo cards are not compatible with YAMT. If you have a Samsung Evo MicroSD card please follow the [StorageMgr](storagemgr) guide.
+{: .notice--warning}
+
 YAMT is only compatible with firmware versions 3.60 and 3.65 on HENkaku Ensō.
 {: .notice--info}
 


### PR DESCRIPTION
Samsung Evos don't work with YAMT. Evo cards fail to work because they take too long to initialise.