### PR TITLE
Made a formatting error on recent pull request #127 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,4 @@
 # vita.hacks.guide
+
+
+This is my personal repo for making pull requests for additions to vita.hacks.guide! So far we've gotten https://github.com/hacks-guide/Guide_Vita/pull/127 added in~

--- a/README.md
+++ b/README.md
@@ -1,4 +1,1 @@
 # vita.hacks.guide
-
-
-This is my personal repo for making pull requests for additions to vita.hacks.guide! So far we've gotten https://github.com/hacks-guide/Guide_Vita/pull/127 added in~

--- a/docs/installing-h-encore.md
+++ b/docs/installing-h-encore.md
@@ -13,7 +13,7 @@ In addition to installing the h-encore exploit, we enable access to “unsafe”
 If you are on firmware versions 3.65 to 3.68, you will be using the h-encore exploit, however if you are on firmware versions 3.69 to 3.73, you will be using the h-encore² exploit. The program we use to install the exploit to your console (finalhe) should sort this out for you.
 
 ::: tip
-If you are unable to get the finalhe method to work for any reason, or if you own a Mac/Linux computer, the [QCMA Backup method](installing-h-encore-(qcma).md) QCMA Backup method will work as well.
+If you are unable to get the finalhe method to work for any reason, or if you own a Mac/Linux computer, the [QCMA Backup method](installing-h-encore-(qcma).md) will work as well.
 :::
 
 ::: tip


### PR DESCRIPTION
This is just fixing a formatting error on my recently merged pull. #127 

![image](https://user-images.githubusercontent.com/77812141/153735854-975ecc55-124d-4a14-ae37-4d96dba48da8.png)
That is shown on the website, and it should just say `If you are unable to get the finalhe method to work for any reason, or if you own a Mac/Linux computer, the QCMA Backup method will work as well.`
So I fixed it.



**Additionally, the same page** (https://vita.hacks.guide/installing-h-encore-(qcma).html) doesn't have the `Updating Firmware...Installing Enso` at the bottom like this, and is not in the sidebar like this:
![image](https://user-images.githubusercontent.com/77812141/153738035-c3926897-8ebe-47a8-ab44-354144fa0cdd.png)

![image](https://user-images.githubusercontent.com/77812141/153738177-21ff935b-79ce-4a4e-9e9b-35ec52aa6d3c.png)


It just has this:
![image](https://user-images.githubusercontent.com/77812141/153738060-6c8a33fb-1f3b-4125-bcd8-7163bcc49ace.png)

![image](https://user-images.githubusercontent.com/77812141/153738195-5ce337e8-771d-410d-b88f-e58445099ebc.png)




I have no idea how to rectify this, it's probably something else that would have to be added to the internal code of the site, I guess?


Sorry for the trouble, thanks for your time, and thanks for merging my prior request!