### PR TITLE
Update yamt.md

### DIFF
--- a/docs/yamt.md
+++ b/docs/yamt.md
@@ -104,6 +104,7 @@ If you decide to do this, you must *not* delete these folders if they exist:
 
   + `uma0:data/bootstrap.self`
   + `uma0:app/PCSG90096`
+  + `uma0:app/VITASHELL`
   + `uma0:appmeta/PCSG90096`
   + `uma0:appmeta/VITASHELL`
   + `uma0:license/app/PCSG90096`


### PR DESCRIPTION
In the section *not* deleting folders, it was missing the app/VITASHELL folder. This folder is needed as you will not have VitaShell  app on Vita if deleted.