### PR TITLE
Allow choosing ○ button behavior to show in guide

### DIFF
--- a/docs/.vuepress/components/Btn.vue
+++ b/docs/.vuepress/components/Btn.vue
@@ -1,0 +1,69 @@
+<template>
+	<kbd :class="type" v-html="char"></kbd>
+</template>
+
+<script>
+	export default {
+		props: {
+			btn: { required: true },
+		},
+
+		data: () => ({
+			_type: "face",
+			_char: ""
+		}),
+
+		computed: {
+			type() { return this._type; },
+			char() { return this._char; }
+		},
+
+		created() {
+			switch(this.btn.toLowerCase()) {
+				case "cross":
+				case "confirm":
+					this._char = "×";
+					break;
+				case "circle":
+				case "cancel":
+					this._char = "○";
+					break;
+				case "triangle":
+					this._char = "△";
+					break;
+				case "square":
+					this._char = "□";
+					break;
+				case "l":
+					this._char = "L";
+					this._type = "l";
+					break;
+				case "r":
+					this._char = "R";
+					this._type = "r";
+					break;
+				default:
+					this._char = this.btn;
+					this._type = "";
+					break;
+			}
+		},
+
+		mounted() {
+			switch(this.btn.toLowerCase()) {
+				case "confirm":
+					this._char = this.isJapanese() ? "○" : "×";
+					break;
+				case "cancel":
+					this._char = this.isJapanese() ? "×" : "○";
+					break;
+			}
+		},
+
+		methods: {
+			isJapanese() {
+				return localStorage.japanese === "true";
+			}
+		}
+	};
+</script>

--- a/docs/.vuepress/components/BtnToggler.vue
+++ b/docs/.vuepress/components/BtnToggler.vue
@@ -1,0 +1,28 @@
+<template>
+	<select @change="this.setJapanese($event.target.value === 'jp')">
+		<option value="int">International (× = Confirm)</option>
+		<option value="jp" :selected="japanese">Japanese (○ = Confirm)</option>
+	</select>
+</template>
+
+<script>
+	export default {
+		data: () => ({
+			_japanese: false
+		}),
+
+		computed: {
+			japanese() { return this._japanese; },
+		},
+
+		mounted() {
+			this._japanese = localStorage.japanese === "true";
+		},
+
+		methods: {
+			setJapanese(jp) {
+				localStorage.japanese = !!jp;
+			}
+		}
+	};
+</script>

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -19,6 +19,12 @@ module.exports = {
 				}
 			}
 		],
+		[
+			'@vuepress/register-components',
+			{
+				componentsDir: path.resolve(__dirname, './components')
+			}
+		],
 	],
   
   themeConfig: {

--- a/docs/.vuepress/styles/index.scss
+++ b/docs/.vuepress/styles/index.scss
@@ -1,0 +1,16 @@
+kbd {
+	&.l {
+		border-radius: 15px 6px 6px 6px;
+		padding: 0 3px 0 7px;
+	}
+
+	&.r {
+		border-radius: 6px 15px 6px 6px;
+		padding: 0 7px 0 3px;
+	}
+
+	&.face {
+		padding: 0 6px;
+		border-radius: 15px;
+	}
+}

--- a/docs/adrenaline.md
+++ b/docs/adrenaline.md
@@ -25,38 +25,38 @@ You must have already installed VitaShell to use this.
 #### Section I - Prep Work
 
 1. Launch the VitaShell application
-1. Press (Select) to enable FTP access on your device
+1. Press <Btn btn="SELECT" /> to enable FTP access on your device
 1. Open your FTP client on your computer
 1. Enter the IP Address and Port displayed on your device
 1. Using your FTP client, navigate to `ux0:` -> `data/`
 1. Transfer `Adrenaline.vpk` to the `data` folder
 1. Transfer `PSPhbb_dev.vpk` to the `data` folder
-1. Press (Circle) on your device to close the FTP connection
+1. Press <Btn btn="cancel" /> on your device to close the FTP connection
 
 #### Section II - Installing VPKs
 
 1. On your device, navigate to `ux0:` -> `data/`
-1. Press (Square) on each of the `.vpk` files to mark them
-1. Press (Triangle) to open the menu, then select "More" -> "Install all" to install the marked files
-1. Press (Cross) to confirm the install
-1. Press (Cross) to continue the install each time you are prompted about extended permissions
-1. Press (Triangle) to open the menu, then select "Delete" to delete the marked files
-1. Press (Cross) to confirm the deletion
+1. Press <Btn btn="square" /> on each of the `.vpk` files to mark them
+1. Press <Btn btn="triangle" /> to open the menu, then select "More" -> "Install all" to install the marked files
+1. Press <Btn btn="confirm" /> to confirm the install
+1. Press <Btn btn="confirm" /> to continue the install each time you are prompted about extended permissions
+1. Press <Btn btn="triangle" /> to open the menu, then select "Delete" to delete the marked files
+1. Press <Btn btn="confirm" /> to confirm the deletion
 
 #### Section III - Modifying Plugin Config
 
-1. Press (Circle) to return to `ux0:`
+1. Press <Btn btn="cancel" /> to return to `ux0:`
 1. Navigate to `tai/`
-    + If `ux0:tai` doesn't exist, press (Circle) again and then navigate to `ur0:tai`
-1. Press (Cross) on `config.txt` to open it in the editor
+    + If `ux0:tai` doesn't exist, press <Btn btn="cancel" /> again and then navigate to `ur0:tai`
+1. Press <Btn btn="confirm" /> on `config.txt` to open it in the editor
 1. Highlight the `*KERNEL` line with the cursor
-1. Press (Triangle) to open the menu, then select "Insert empty line"
+1. Press <Btn btn="triangle" /> to open the menu, then select "Insert empty line"
 1. Highlight the new blank line
-1. Press (Cross) to edit the line
+1. Press <Btn btn="confirm" /> to edit the line
 1. Enter the following text:
     + `ux0:app/PSPEMUCFW/sce_module/adrenaline_kernel.skprx`
-1. Press (Circle) to close the editor
-1. When prompted, press (Cross) to save your modifications
+1. Press <Btn btn="cancel" /> to close the editor
+1. When prompted, press <Btn btn="confirm" /> to save your modifications
 1. Close the VitaShell application
 1. Reboot your device
     + If your device does not have Ensō, you will need to manually launch and exit h-encore to enable homebrew
@@ -65,17 +65,17 @@ You must have already installed VitaShell to use this.
 #### Section IV - Installing PSP XMB
 
 1. Launch the Adrenaline application
-1. Press (Cross) to download the PSP 6.61 firmware
+1. Press <Btn btn="cross" /> to download the PSP 6.61 firmware
     + This process will take some time
     + If the download fails, the downloader will get confused and begin to give you the error `Cannot find ux0:/app/PSPEMUCFW/661.PBP`
     + If you encounter the above error, use VitaShell to delete the `ux0:app/PSPEMUCFW/flash0/` folder, then try again
     + If you still encounter this error, manually download [EBOOT.PBP](http://de01.psp.update.playstation.org/update/psp/image/eu/2014_1212_6be8878f475ac5b1a499b95ab2f7d301/EBOOT.PBP), rename it to `661.PBP`, then transfer it to `ux0:app/PSPEMUCFW/` using VitaShell
     + The Adrenaline application will close automatically when the download is complete
 1. Re-launch the Adrenaline application
-1. Press (Cross) to install PSP 6.61 the firmware
-1. Press (Cross) to boot the PSP home menu
+1. Press <Btn btn="cross" /> to install PSP 6.61 the firmware
+1. Press <Btn btn="cross" /> to boot the PSP home menu
     + The PSP home menu is also known as the [XrossMediaBar](https://wikipedia.org/wiki/XrossMediaBar) ("XMB")
 1. Perform the PSP Initial Setup
-1. To close the PSP Emulator, hold the (PS) button to open the menu, then select `Settings` -> `Exit PspEmu Application`
+1. To close the PSP Emulator, hold the <Btn btn="PS" /> button to open the menu, then select `Settings` -> `Exit PspEmu Application`
 
 Adrenaline and the PSP Homebrew Browser have been successfully installed.

--- a/docs/configuring-h-encore.md
+++ b/docs/configuring-h-encore.md
@@ -11,7 +11,7 @@ As a result, you will have to perform the h-encore exploit manually after each r
 
 ### Instructions
 
-1. Launch the h-encore application while holding (R)
+1. Launch the h-encore application while holding <Btn btn="r" />
 1. Select "Personalize savedata"
 1. Select "Exit"
 

--- a/docs/downgrading-firmware-(3.60).md
+++ b/docs/downgrading-firmware-(3.60).md
@@ -31,43 +31,43 @@ Ensure your device has a battery charge of 50% or greater before proceeding.
 #### Section I - Prep Work
 
 1. Launch the VitaShell application
-1. Press (Start) to open the VitaShell settings
-1. Press (Cross) on "SELECT button" to change the mode to "FTP"
+1. Press <Btn btn="START" /> to open the VitaShell settings
+1. Press <Btn btn="confirm" /> on "SELECT button" to change the mode to "FTP"
     + Alternatively, you can leave this setting on "USB" and transfer all files via a USB cable for the remainder of this guide
     + Note that the USB transfer mode will start you in the ux0 partition
     + Additionally, some files will be hidden in USB mode on Windows; you must enable "Show hidden files, folders, and drives" and disable "Hide protected operating system files" in the File Explorer options in order to see all files
-1. Press (Circle) to close the VitaShell settings
-1. Press (Select) to enable FTP access on your device
+1. Press <Btn btn="cancel" /> to close the VitaShell settings
+1. Press <Btn btn="SELECT" /> to enable FTP access on your device
 1. Open your FTP client on your computer
 1. Enter the IP Address and Port displayed on your device
 1. Using your FTP client, navigate to `ux0:` -> `data/`
 1. Transfer `modoru.vpk` to the `data` folder
 1. Transfer `PSP2UPDAT.PUP` to the `data` folder
-1. Press (Circle) on your device to close the FTP connection
+1. Press <Btn btn="cancel" /> on your device to close the FTP connection
 
 #### Section II - Installing modoru
 
 1. On your device, navigate to `ux0:` -> `data/`
-1. Press (Cross) on `modoru.vpk` to install it
-1. Press (Cross) to confirm the install
-1. Press (Cross) to continue the install when you are prompted about extended permissions
-1. Press (Triangle) to open the menu, then select "Delete" to delete `modoru.vpk`
-1. Press (Cross) to confirm the deletion
-1. Press (Triangle) on `PSP2UPDAT.PUP` to open the menu, then select "Copy"
-1. Press (Cross) to dismiss the copied file dialogue box
-1. Press (Circle) to return to the `ux0:` partition
+1. Press <Btn btn="confirm" /> on `modoru.vpk` to install it
+1. Press <Btn btn="confirm" /> to confirm the install
+1. Press <Btn btn="confirm" /> to continue the install when you are prompted about extended permissions
+1. Press <Btn btn="triangle" /> to open the menu, then select "Delete" to delete `modoru.vpk`
+1. Press <Btn btn="confirm" /> to confirm the deletion
+1. Press <Btn btn="triangle" /> on `PSP2UPDAT.PUP` to open the menu, then select "Copy"
+1. Press <Btn btn="confirm" /> to dismiss the copied file dialogue box
+1. Press <Btn btn="cancel" /> to return to the `ux0:` partition
 1. Navigate to `app` -> `MODORU000`
-1. Press (Triangle) to open the menu, then select "Paste" to paste `PSP2UPDAT.PUP` in the current folder
-1. Press (Circle) to return to the `ux0:` partition
-1. Press (Triangle) on `tai` to open the menu, then select "Delete" to delete the `tai` folder
-1. Press (Cross) to confirm the deletion
+1. Press <Btn btn="triangle" /> to open the menu, then select "Paste" to paste `PSP2UPDAT.PUP` in the current folder
+1. Press <Btn btn="cancel" /> to return to the `ux0:` partition
+1. Press <Btn btn="triangle" /> on `tai` to open the menu, then select "Delete" to delete the `tai` folder
+1. Press <Btn btn="confirm" /> to confirm the deletion
 1. Close the VitaShell application
 
 #### Section III - Downgrading Prep
 
 1. Reboot your device
-1. Launch the h-encore application while holding (R)
-    + If prompted about trophies, continue holding (R) and select "Yes"
+1. Launch the h-encore application while holding <Btn btn="r" />
+    + If prompted about trophies, continue holding <Btn btn="r" /> and select "Yes"
 1. If the exploit was successful, you will now see the h-encore bootstrap menu
     + If the exploit is stuck on a white screen, simply close the application (which will cause a crash and reboot your device), then try again
     + If it is still stuck, hold the power button down for over 30 seconds to force a reboot, then try again
@@ -83,13 +83,13 @@ Ensure your device has a battery charge of 50% or greater before proceeding.
 #### Section IV - Downgrading
 
 1. Launch the modoru application
-1. Press (Cross) to confirm the downgrade to firmware version 3.60
+1. Press <Btn btn="confirm" /> to confirm the downgrade to firmware version 3.60
     + If you are given the message "Error you cannot go lower than your factory firmware.", you will be unable to downgrade to firmware version 3.60
     + If you are currently on firmware version 3.65, proceed to [Installing Ensō (3.65)](installing-enso-(3.65))
     + If you are currently on a firmware version above 3.65 and the listed "Factory firmware" is 3.65 or lower, proceed to [Downgrading Firmware (3.65)](downgrading-firmware-(3.65))
     + If you are currently on a firmware version above 3.65 and the listed "Factory firmware" is greater than 3.65, proceed to [Configuring h-encore](configuring-h-encore)
     + If you are currently on a firmware above 3.69 and the listed "Factory firmware" is greater than 3.68, proceed to [Finalizing Setup](finalizing-setup)
-1. Press (Cross) to accept the terms and conditions
+1. Press <Btn btn="confirm" /> to accept the terms and conditions
 1. Your device will begin the downgrade process
 1. Wait until the process is completed, your device will reboot automatically
 

--- a/docs/downgrading-firmware-(3.65).md
+++ b/docs/downgrading-firmware-(3.65).md
@@ -23,53 +23,53 @@ Ensure your device has a battery charge of 50% or greater before proceeding.
 
 1. Exit the modoru application
 1. Launch the VitaShell application
-1. Press (Start) to open the VitaShell settings
-1. Press (Cross) on "SELECT button" to change the mode to "FTP"
+1. Press <Btn btn="START" /> to open the VitaShell settings
+1. Press <Btn btn="confirm" /> on "SELECT button" to change the mode to "FTP"
     + Alternatively, you can leave this setting on "USB" and transfer all files via a USB cable for the remainder of this guide
     + Note that the USB transfer mode will start you in the ux0 partition
     + Additionally, some files will be hidden in USB mode on Windows; you must enable "Show hidden files, folders, and drives" and disable "Hide protected operating system files" in the File Explorer options in order to see all files
-1. Press (Circle) to close the VitaShell settings
-1. Press (Select) to enable FTP access on your device
+1. Press <Btn btn="cancel" /> to close the VitaShell settings
+1. Press <Btn btn="SELECT" /> to enable FTP access on your device
 1. Open your FTP client on your computer
 1. Enter the IP Address and Port displayed on your device
 1. Using your FTP client, navigate to `ux0:` -> `data/`
 1. Delete the existing 3.60 `PSP2UPDAT.PUP` file
 1. Transfer the 3.65 `PSP2UPDAT.PUP` to the `data` folder
-1. Press (Circle) on your device to close the FTP connection
+1. Press <Btn btn="cancel" /> on your device to close the FTP connection
 
 #### Section II - Installing modoru
 
 1. On your device, navigate to `ux0:` -> `data/`
-1. Press (Cross) on `modoru.vpk` to install it
-1. Press (Cross) to confirm the install
-1. Press (Cross) to continue the install when you are prompted about extended permissions
-1. Press (Triangle) to open the menu, then select "Delete" to delete `modoru.vpk`
-1. Press (Cross) to confirm the deletion
-1. Press (Triangle) on the 3.65 `PSP2UPDAT.PUP` to open the menu, then select "Copy"
-1. Press (Cross) to dismiss the copied file dialogue box
-1. Press (Circle) to return to the `ux0:` partition
+1. Press <Btn btn="confirm" /> on `modoru.vpk` to install it
+1. Press <Btn btn="confirm" /> to confirm the install
+1. Press <Btn btn="confirm" /> to continue the install when you are prompted about extended permissions
+1. Press <Btn btn="triangle" /> to open the menu, then select "Delete" to delete `modoru.vpk`
+1. Press <Btn btn="confirm" /> to confirm the deletion
+1. Press <Btn btn="triangle" /> on the 3.65 `PSP2UPDAT.PUP` to open the menu, then select "Copy"
+1. Press <Btn btn="confirm" /> to dismiss the copied file dialogue box
+1. Press <Btn btn="cancel" /> to return to the `ux0:` partition
 1. Navigate to `app` -> `MODORU000`
-1. Press (Triangle) on the existing 3.60 `PSP2UPDAT.PUP` to open the menu, then select "Delete"
-1. Press (Cross) to confirm the deletion
-1. Press (Triangle) to open then menu, then select "Paste" to paste the 3.65 `PSP2UPDAT.PUP` in the current folder
-1. Press (Circle) to return to the `ux0:` partition
-1. Press (Triangle) on `tai` to open the menu, then select "Delete" to delete the `tai` folder
-1. Press (Cross) to confirm the deletion
+1. Press <Btn btn="triangle" /> on the existing 3.60 `PSP2UPDAT.PUP` to open the menu, then select "Delete"
+1. Press <Btn btn="confirm" /> to confirm the deletion
+1. Press <Btn btn="triangle" /> to open then menu, then select "Paste" to paste the 3.65 `PSP2UPDAT.PUP` in the current folder
+1. Press <Btn btn="cancel" /> to return to the `ux0:` partition
+1. Press <Btn btn="triangle" /> on `tai` to open the menu, then select "Delete" to delete the `tai` folder
+1. Press <Btn btn="confirm" /> to confirm the deletion
 1. Close the VitaShell application
 
 #### Section III - Downgrading
 
 1. Reboot your device
-1. Launch the h-encore application while holding (R)
-    + If prompted about trophies, continue holding (R) and select "Yes"
+1. Launch the h-encore application while holding <Btn btn="r" />
+    + If prompted about trophies, continue holding <Btn btn="r" /> and select "Yes"
 1. If the exploit was successful, you will now see the h-encore bootstrap menu
     + If the exploit is stuck on a white screen, simply close the application (which will cause a crash and reboot your device), then try again
     + If it is still stuck, hold the power button down for over 30 seconds to force a reboot, then try again
 1. Select "Install HENkaku"
 1. Select "Exit"
 1. Launch the modoru application
-1. Press (Cross) to confirm the downgrade to firmware version 3.65
-1. Press (Cross) to accept the terms and conditions
+1. Press <Btn btn="confirm" /> to confirm the downgrade to firmware version 3.65
+1. Press <Btn btn="confirm" /> to accept the terms and conditions
 1. Your device will begin the downgrade process
 1. Wait until the process is completed, your device will reboot automatically
 

--- a/docs/finalizing-setup-(legacy).md
+++ b/docs/finalizing-setup-(legacy).md
@@ -36,11 +36,11 @@ In order to install the necessary `.vpk` (content package) file on your device, 
 #### Section I - Prep Work
 
 1. Launch the VitaShell application
-1. Press (Start) to open the VitaShell settings
-1. Press (Cross) on "SELECT button" to change the mode to "FTP"
+1. Press <Btn btn="START" /> to open the VitaShell settings
+1. Press <Btn btn="confirm" /> on "SELECT button" to change the mode to "FTP"
     + You cannot use USB file transfer for this section
-1. Press (Circle) to close the VitaShell settings
-1. Press (Select) to enable FTP access on your device
+1. Press <Btn btn="cancel" /> to close the VitaShell settings
+1. Press <Btn btn="SELECT" /> to enable FTP access on your device
 1. Open your FTP client on your computer
 1. Enter the IP Address and Port displayed on your device
 1. Using your FTP client, navigate to `ux0:`
@@ -59,25 +59,25 @@ In order to install the necessary `.vpk` (content package) file on your device, 
 1. Transfer `shellbat.suprx` to the `tai/` folder
 1. Transfer `pngshot.suprx` to the `tai/` folder
 1. Transfer `PSVshell.skprx` to the `tai/` folder
-1. Press (Circle) on your device to close the FTP connection
+1. Press <Btn btn="cancel" /> on your device to close the FTP connection
     + For more information on plugins and their installation, read [this webpage](https://samilops2.gitbook.io/vita-troubleshooting-guide/plugins-related-problem/error-when-using-autoplugin)
 
 #### Section II - Installing homebrew applications
 
 1. Launch the VitaShell application
 1. Navigate to `ux0:` -> `data/`
-1. Press (Triangle) to open the side menu
-1. Press (Cross) on "Mark all"
-1. Press (Triangle) to open the side menu again
-1. Press (Cross) on "More"
-1. Press (Cross) on "Install all"
-1. Press (Cross) to confirm the install
-1. Press (Cross) to confirm the install again when prompted
+1. Press <Btn btn="triangle" /> to open the side menu
+1. Press <Btn btn="confirm" /> on "Mark all"
+1. Press <Btn btn="triangle" /> to open the side menu again
+1. Press <Btn btn="confirm" /> on "More"
+1. Press <Btn btn="confirm" /> on "Install all"
+1. Press <Btn btn="confirm" /> to confirm the install
+1. Press <Btn btn="confirm" /> to confirm the install again when prompted
 
 #### Section III - Installing iTLS
 
 1. Open the iTLS-Enso application
-1. Press (Cross) on "Install the full iTLS package"
+1. Press <Btn btn="cross" /> on "Install the full iTLS package"
     + If not on HENkaku Ensō, select "Install the iTLS compat module (web-browser)" instead
 1. Wait for your device to reboot
 

--- a/docs/finalizing-setup.md
+++ b/docs/finalizing-setup.md
@@ -29,18 +29,18 @@ In order to install the necessary applications on your device, we use the VitaDe
 1. Tap "Download the selected apps"
 1. Wait for the app to finish downloading
     + When finished, you should be presented with a list of two `.vpk` files
-1. Press (Triangle) to open the side menu
-1. Press (Cross) on "Mark all"
-1. Press (Triangle) to open the side menu again
-1. Press (Cross) on "More"
-1. Press (Cross) on "Install all"
-1. Press (Cross) to confirm the install
-1. Press (Cross) to confirm the install again when prompted
+1. Press <Btn btn="triangle" /> to open the side menu
+1. Press <Btn btn="confirm" /> on "Mark all"
+1. Press <Btn btn="triangle" /> to open the side menu again
+1. Press <Btn btn="confirm" /> on "More"
+1. Press <Btn btn="confirm" /> on "Install all"
+1. Press <Btn btn="confirm" /> to confirm the install
+1. Press <Btn btn="confirm" /> to confirm the install again when prompted
 
 #### Section II - Installing iTLS
 
 1. Open the iTLS-Enso application
-1. Press (Cross) on "Install the full iTLS package"
+1. Press <Btn btn="cross" /> on "Install the full iTLS package"
     + If not on HENkaku Ensō, select "Install the iTLS compat module (web-browser)" instead
 1. Wait for your device to reboot
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -30,6 +30,11 @@ Click the language button at the top right of the page to change the language.
 Alternatively, click [here](https://crowdin.com/project/vita-guide) to help to keep these translations up to date.
 :::-->
 
+::: tip
+**Important**: Please select your button layout: <BtnToggler />
+
+:::
+
 ## What is Homebrew?
 
 [**Homebrew**](https://en.wikipedia.org/wiki/List_of_homebrew_video_games) usually refers to software that is not authorized by Sony. It allows you to run homebrew games, tools like save editing and backup, and emulators for various older systems.

--- a/docs/installing-enso-(3.60).md
+++ b/docs/installing-enso-(3.60).md
@@ -20,30 +20,30 @@ It is more convenient than HENkaku as it does not require you to trigger an expl
 #### Section I - Prep Work
 
 1. Launch the molecularShell or VitaShell application
-1. Press (Select) to enable FTP access on your device
+1. Press <Btn btn="SELECT" /> to enable FTP access on your device
 1. Open your FTP client on your computer
 1. Enter the IP Address and Port displayed on your device
 1. Using your FTP client, navigate to `ux0:` -> `data/`
 1. Transfer `enso.vpk` to the `data` folder
 1. Transfer `VitaShell.vpk` to the `data` folder
-1. Press (Circle) on your device to close the FTP connection
+1. Press <Btn btn="cancel" /> on your device to close the FTP connection
 
 #### Section II - Installing VPKs
 
 1. On your device, navigate to `ux0:` -> `data/`
-1. Press (Square) on each of the `.vpk` files to mark them
-1. Press (Triangle) to open the menu, then select "More" -> "Install all" to install the marked files
-1. Press (Cross) to confirm the install
-1. Press (Cross) to continue the install each time you are prompted about extended permissions
-1. Press (Triangle) to open the menu, then select "Delete" to delete the marked files
-1. Press (Cross) to confirm the deletion
+1. Press <Btn btn="square" /> on each of the `.vpk` files to mark them
+1. Press <Btn btn="triangle" /> to open the menu, then select "More" -> "Install all" to install the marked files
+1. Press <Btn btn="cross" /> to confirm the install
+1. Press <Btn btn="cross" /> to continue the install each time you are prompted about extended permissions
+1. Press <Btn btn="triangle" /> to open the menu, then select "Delete" to delete the marked files
+1. Press <Btn btn="cross" /> to confirm the deletion
 1. Close the molecularShell or VitaShell application
 
 #### Section III - Installing Ensō
 
 1. Open the Ensō application
-1. Press (Circle) to accept the terms
-1. Press (Cross) to install Ensō
+1. Press <Btn btn="circle" /> to accept the terms
+1. Press <Btn btn="cross" /> to install Ensō
     + When the process has completed, press any button to reboot your device
 
 ::: tip

--- a/docs/installing-enso-(3.65).md
+++ b/docs/installing-enso-(3.65).md
@@ -20,34 +20,34 @@ Unfortunately, you may experience minor software incompatibilities as you will n
 #### Section I - Prep Work
 
 1. Launch the VitaShell application
-1. Press (Start) to open the VitaShell settings
-1. Press (Cross) on "SELECT button" to change the mode to "FTP"
+1. Press <Btn btn="START" /> to open the VitaShell settings
+1. Press <Btn btn="confirm" /> on "SELECT button" to change the mode to "FTP"
     + Alternatively, you can leave this setting on "USB" and transfer all files via a USB cable for the remainder of this guide
     + Note that the USB transfer mode will start you in the ux0 partition
     + Additionally, some files will be hidden in USB mode on Windows; you must enable "Show hidden files, folders, and drives" and disable "Hide protected operating system files" in the File Explorer options in order to see all files
-1. Press (Circle) to close the VitaShell settings
-1. Press (Select) to enable FTP access on your device
+1. Press <Btn btn="cancel" /> to close the VitaShell settings
+1. Press <Btn btn="SELECT" /> to enable FTP access on your device
 1. Open your FTP client on your computer
 1. Enter the IP Address and Port displayed on your device
 1. Using your FTP client, navigate to `ux0:` -> `data/`
 1. Transfer `enso.vpk` to the `data` folder
-1. Press (Circle) on your device to close the FTP connection
+1. Press <Btn btn="cancel" /> on your device to close the FTP connection
 
 #### Section II - Installing VPK
 
 1. On your device, navigate to `ux0:` -> `data/`
-1. Press (Cross) on `enso.vpk` to install the file
-1. Press (Cross) to confirm the install
-1. Press (Cross) to continue the install when you are prompted about extended permissions
-1. Press (Triangle) to open the menu, then select "Delete" to delete the marked file
-1. Press (Cross) to confirm the deletion
+1. Press <Btn btn="confirm" /> on `enso.vpk` to install the file
+1. Press <Btn btn="confirm" /> to confirm the install
+1. Press <Btn btn="confirm" /> to continue the install when you are prompted about extended permissions
+1. Press <Btn btn="triangle" /> to open the menu, then select "Delete" to delete the marked file
+1. Press <Btn btn="confirm" /> to confirm the deletion
 1. Close the VitaShell application
 
 #### Section III - Installing Ensō
 
 1. Open the Ensō application
-1. Press (Circle) to accept the terms
-1. Press (Cross) to install Ensō
+1. Press <Btn btn="circle" /> to accept the terms
+1. Press <Btn btn="cross" /> to install Ensō
     + When the process has completed, press any button to reboot your device
 
 ::: tip

--- a/docs/installing-enso.md
+++ b/docs/installing-enso.md
@@ -27,9 +27,9 @@ This mod will make PERMANENT modifications to your device. If anything goes wron
 1. Tap "Quick 3.65 Install"
     + You must be connected to the internet to use this
 1. Wait for the components to download
-1. Press (Cross) to confirm
+1. Press <Btn btn="cross" /> to confirm
 1. Read the notice given on the screen and wait 20 seconds
-1. Press (Cross) again to confirm
+1. Press <Btn btn="cross" /> again to confirm
     + If you changed your mind, you can press R to exit instead
 
 Your device will then install firmware version 3.65, alongside with HENkaku Ensō. Once finished, it will reboot into CFW mode.

--- a/docs/installing-h-encore-(qcma).md
+++ b/docs/installing-h-encore-(qcma).md
@@ -51,12 +51,12 @@ This method should be used if the finalhe method of hacking your Vita does not w
 
 #### Section III - Opening h-encore
 
-1. Launch the h-encore² application while holding down the (R) button
-    + If prompted about trophies, select "Yes" while continuing to hold down the (R) button
+1. Launch the h-encore² application while holding down the <Btn btn="r" /> button
+    + If prompted about trophies, select "Yes" while continuing to hold down the <Btn btn="r" /> button
 1. If the exploit was successful, you will now see the h-encore bootstrap menu
     + If the exploit gets stuck, reboot your device and try again
     + If you can't reboot normally, hold the power button down for over 30 seconds to force a reboot
-1. Press (Cross) to exit the application
+1. Press <Btn btn="confirm" /> to exit the application
 
 #### Section IV - Configuring HENkaku
 
@@ -66,3 +66,7 @@ This method should be used if the finalhe method of hacking your Vita does not w
 1. Check "Enable Unsafe Homebrew"
 1. Return to HENkaku Settings menu
 1. Close the Settings application
+
+::: tip
+You can change your <Btn btn="circle" /> button behavior now. If you do, change it for the guide too: <BtnToggler />
+:::

--- a/docs/installing-h-encore.md
+++ b/docs/installing-h-encore.md
@@ -72,12 +72,12 @@ If you have a PS Vita 1000, you must also have an official Sony memory card (of 
 
 #### Section III - Opening h-encore
 
-1. Launch the h-encore(²) application while holding down the (R) button
-    + If prompted about trophies, select "Yes" while continuing to hold down the (R) button
+1. Launch the h-encore(²) application while holding down the <Btn btn="r" /> button
+    + If prompted about trophies, select "Yes" while continuing to hold down the <Btn btn="r" /> button
 1. If the exploit was successful, you will now see the h-encore bootstrap menu
     + If the exploit gets stuck, reboot your device and try again
     + If you can't reboot normally, hold the power button down for over 30 seconds to force a reboot
-1. Press (Cross) to exit the application
+1. Press <Btn btn="confirm" /> to exit the application
 
 #### Section IV - Configuring HENkaku
 
@@ -87,3 +87,7 @@ If you have a PS Vita 1000, you must also have an official Sony memory card (of 
 1. Check "Enable Unsafe Homebrew"
 1. Return to HENkaku Settings menu
 1. Close the Settings application
+
+::: tip
+You can change your <Btn btn="circle" /> button behavior now. If you do, change it for the guide too: <BtnToggler />
+:::

--- a/docs/installing-henkaku.md
+++ b/docs/installing-henkaku.md
@@ -39,16 +39,16 @@ If you have VitaShell installed from a previous homebrew installation, HENkaku w
 #### Section II - Installing VitaDeploy
 
 1. Launch the molecularShell application
-1. Press (Select) to enable FTP access on your device
+1. Press <Btn btn="SELECT" /> to enable FTP access on your device
 1. Open your FTP client on your computer
 1. Enter the IP Address and Port displayed on your device
 1. Using your FTP client, navigate to `ux0:` -> `data/`
 1. Transfer `VitaDeploy.vpk` to the `data` folder
-1. Press (Circle) on your device to close the FTP connection
+1. Press <Btn btn="cancel" /> on your device to close the FTP connection
 1. On your device, navigate to `ux0:` -> `data/`
-1. Press (Cross) on `VitaDeploy.vpk` to install it
-1. Press (Cross) again to confirm the install
-1. Press (Cross) once more to confirm again
+1. Press <Btn btn="confirm" /> on `VitaDeploy.vpk` to install it
+1. Press <Btn btn="confirm" /> again to confirm the install
+1. Press <Btn btn="confirm" /> once more to confirm again
 1. Close the molecularShell application
 
 #### Section III - Configuring HENkaku
@@ -58,3 +58,7 @@ If you have VitaShell installed from a previous homebrew installation, HENkaku w
 1. Check "Enable Unsafe Homebrew"
 1. Return to HENkaku Settings menu
 1. Close the Settings application
+
+::: tip
+You can change your <Btn btn="circle" /> button behavior now. If you do, change it for the guide too: <BtnToggler />
+:::

--- a/docs/installing-vitadeploy.md
+++ b/docs/installing-vitadeploy.md
@@ -17,23 +17,23 @@ In order to install the necessary `.vpk` (content package) file on your device, 
 #### Section I - Prep Work
 
 1. Launch the VitaShell application
-1. Press (Start) to open the VitaShell settings
-1. Press (Cross) on "SELECT button" to change the mode to "FTP"
+1. Press <Btn btn="START" /> to open the VitaShell settings
+1. Press <Btn btn="confim" /> on "SELECT button" to change the mode to "FTP"
     + Alternatively, you can leave this setting on "USB" and transfer all files via a USB cable for the remainder of this guide
-1. Press (Circle) to close the VitaShell settings
-1. Press (Select) to enable FTP access on your device
+1. Press <Btn btn="cancel" /> to close the VitaShell settings
+1. Press <Btn btn="SELECT" /> to enable FTP access on your device
 1. Open your FTP client on your computer
 1. Enter the IP Address and Port displayed on your device
 1. Using your FTP client, navigate to `ux0:` -> `data/`
 1. Transfer `VitaDeploy.vpk` to the `data/` folder
-1. Press (Circle) on your device to close the FTP connection
+1. Press <Btn btn="cancel" /> on your device to close the FTP connection
 
 #### Section II - Installing the application
 
 1. Launch the VitaShell application
 1. Navigate to `ux0:` -> `data/`
-1. Press (Cross) on "VitaDeploy.vpk"
-1. Press (Cross) to confirm the install
-1. Press (Cross) to confirm the install again when prompted
+1. Press <Btn btn="confirm" /> on "VitaDeploy.vpk"
+1. Press <Btn btn="confirm" /> to confirm the install
+1. Press <Btn btn="confirm" /> to confirm the install again when prompted
 
 VitaDeploy should now be installed to your home screen.

--- a/docs/storagemgr.md
+++ b/docs/storagemgr.md
@@ -35,7 +35,7 @@ You must have already installed VitaShell to use this.
 #### Section I - Installing Plugins
 
 1. Launch the VitaShell application
-1. Press (Select) to enable FTP access on your device
+1. Press <Btn btn="SELECT" /> to enable FTP access on your device
 1. Open your FTP client on your computer
 1. Enter the IP Address and Port displayed on your device
 1. Using your FTP client, copy all files from `ux0:tai/` to `ur0:tai/`
@@ -61,7 +61,7 @@ This section will copy the data from your old Sony memory card to your new stora
     + This may take some time if you have a large amount of data on your Sony memory card
     + Do not copy the `ux0:` folder itself to your new storage device
 1. Insert your new storage device into your PS Vita (TV)
-1. Press (Circle) on your device to close the FTP connection
+1. Press <Btn btn="cancel" /> on your device to close the FTP connection
 1. Close the VitaShell application
 1. Reboot your device
     + If your device does not have Ensō, you will need to manually launch and exit h-encore to enable homebrew

--- a/docs/updating-firmware-(ps-tv-3.65).md
+++ b/docs/updating-firmware-(ps-tv-3.65).md
@@ -30,7 +30,7 @@ Note that a custom update application can only update your device, not downgrade
 
 1. Power off your PS TV completely
 1. Hold the power button for at least 7 seconds to boot into safe-mode
-1. Connect a controller using a USB cable, then press the (PS) button
+1. Connect a controller using a USB cable, then press the <Btn btn="PS" /> button
 1. Navigate to `Update System Software` -> `Update from USB Storage Device`
 1. Connect your USB drive to your PS TV
 1. Follow the prompts to update your device

--- a/docs/yamt.md
+++ b/docs/yamt.md
@@ -33,23 +33,23 @@ Red Samsung Evo cards are not compatible with YAMT. If you have a Red Samsung Ev
 #### Section I - Installing YAMT VPK
 
 1. On your device, open VitaDeploy
-1. Press (Cross) on App Downloader
-1. Select (Cross) YAMT Installer
-1. Press (Cross) on Download the selected apps
-1. Press (Cross) on `YAMT.vpk` and confirm with (Cross) again to install
+1. Press <Btn btn="confirm" /> on App Downloader
+1. Select <Btn btn="confirm" /> YAMT Installer
+1. Press <Btn btn="confirm" /> on Download the selected apps
+1. Press <Btn btn="confirm" /> on `YAMT.vpk` and confirm with <Btn btn="confirm" /> again to install
 1. Once done Close out of the VitaDeploy application
 
 #### Section III - Formatting the microSD
 
 1. Insert your SD2Vita with the microSD card into your PS Vita or PS TV device
 1. Launch the VitaDeploy application
-1. Press (Cross) on Miscellaneous
-1. Press (Cross) on Format a storage device
+1. Press <Btn btn="confirm" /> on Miscellaneous
+1. Press <Btn btn="confirm" /> on Format a storage device
 1. Ensure `Target` is set to "SD2Vita" and `Filesystem` is set to "TexFAT"
-1. Press (Cross) on "Format target storage"
+1. Press <Btn btn="confirm" /> on "Format target storage"
     + If this fails, ensure the adapter is inserted properly and is undamaged - then reboot and try again
     + If it still fails, follow the [StorageMgr](storagemgr) guide
-1. Press (Cross) on "Reboot your device"
+1. Press <Btn btn="confirm" /> on "Reboot your device"
 
 #### Section IV - Installing yamt-vita
 
@@ -58,7 +58,7 @@ If you previously installed StorageMgr or another storage plugin, please remove 
 
 1. Power on your device to reboot
 1. Launch the YAMT Installer application
-1. Press (Cross) on `-> Install the lite version`
+1. Press <Btn btn="cross" /> on `-> Install the lite version`
     + Once finished, your device will reboot
 1. Open the Settings application
 1. Navigate to `Devices` -> `Storage Devices`
@@ -79,15 +79,15 @@ This section will copy the data from your old Sony memory card (or internal stor
 1. Navigate to the `ux0:` partition
     + This is currently your official memory card or internal storage
 1. Press down on the D-Pad to highlight a folder or file
-1. Press (Triangle) to bring up the menu
-1. Press (Cross) on "Mark all" to select all folders and files in the `ux0:` partition
-1. Press (Triangle) again to bring up the menu
-1. Press (Cross) on "Copy"
-1. Press (Cross) again when prompted
+1. Press <Btn btn="triangle" /> to bring up the menu
+1. Press <Btn btn="confirm" /> on "Mark all" to select all folders and files in the `ux0:` partition
+1. Press <Btn btn="triangle" /> again to bring up the menu
+1. Press <Btn btn="confirm" /> on "Copy"
+1. Press <Btn btn="confirm" /> again when prompted
 1. Navigate out of the `ux0:` partition and enter the `uma0:` partition
     + This is your unofficial storage device's memory
-1. Press (Triangle) to bring up the menu
-1. Press (Cross) on paste and wait for it to finish
+1. Press <Btn btn="triangle" /> to bring up the menu
+1. Press <Btn btn="confirm" /> on paste and wait for it to finish
 1. Once done, exit VitaShell and open the Settings application
 1. Navigate to `Devices` -> `Storage Devices`
 1. Set `ux0:` to "SD2Vita"

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     },
     "devDependencies": {
         "@vue/component-compiler-utils": "^3.3.0",
+        "@vuepress/plugin-register-components": "2.0.0-beta.26",
         "@vuepress/plugin-search": "2.0.0-beta.26",
         "@vuepress/shared-utils": "^1.8.2",
         "markdown-it-include": "^2.0.0",


### PR DESCRIPTION
- This makes it so that you can choose whether the guide should use ○ = Confirm or × = Confirm, to reduce confusion when modding a Japanese console
- Also changes the buttons to use `<kbd>` tags similar to dsi.cfw.guide
   - I used Vue components so you simply do `<Btn btn="[something]" />`, the special buttons are (case insensitive) `confirm` = ○ (jp) or × (int), `cancel` = × (jp) or ○ (int), `cross` = ×, `circle` = ○, `square` = □, `triangle` = △, `l` = L, `r` = R, anything else will simply be passed through as the inner HTML
   - Currently using the Unicode characters ○/×/□/△, however these don't look great in all fonts so it may be better to switch to SVG or PNG files akin to how Sony does it on their own websites
   - Would also be possible to keep it (Button name), though imo it's better to use the shapes
- To select your button layout I just did a tip box on the home page and below configuring HENkaku settings (since you're able to change behaviour then), might be a better way to do it
- Live at https://vita.ピケ.コム/ if anyone wants to try it
- Fixes #111

!! Important note to anyone editing the guide in the future: When using ○ or ×, use `confirm` and `cancel` if the program correctly handles the difference between Japanese and International (it's most likely this if you're unsure) only use `circle` or `cross` if you're sure that the program does *not* correctly adjust.