### PR TITLE
Fixed #137 by integrating the QCMA version of h-encore into sidebar (probably?)

### DIFF
--- a/docs/.vuepress/configs/en_US.js
+++ b/docs/.vuepress/configs/en_US.js
@@ -56,7 +56,7 @@ module.exports = {
       },
     ],
       
-    sidebar: {
+     sidebar: {
       '/': [
         {
           text: 'Guide',
@@ -65,6 +65,9 @@ module.exports = {
             'get-started',
             'updating-firmware-(3.73)',
             'installing-h-encore',
+             children: [
+             'uninstalling-cfw.md',
+              ],
             'installing-enso',
             'finalizing-setup'
           ],

--- a/docs/.vuepress/configs/en_US.js
+++ b/docs/.vuepress/configs/en_US.js
@@ -56,7 +56,7 @@ module.exports = {
       },
     ],
       
-     sidebar: {
+    sidebar: {
       '/': [
         {
           text: 'Guide',


### PR DESCRIPTION
Just gonna copy what I said in my issue #137:


> The QCMA version of installing h-encore is not included in the sidebar of the site, along with the "proceed to..." part on the bottom.
> In order to make that section of the site more user-friendly, I'll make an addition to /docs/.vuepress/configs/en_US.js to (hopefully) rectify this.
> 
> What I plan to do is:
> 
> This following section is from lines 59-72 of en_US.js.
> 
>  sidebar: {
>       '/': [
>         {
>           text: 'Guide',
>           children: [
>             'index.html',
>             'get-started',
>             'updating-firmware-(3.73)',
>             'installing-h-encore',
>             'installing-enso',
>             'finalizing-setup'
>           ],
>         },
>       ],
> What I'll add is this:
> 
>  sidebar: {
>       '/': [
>         {
>           text: 'Guide',
>           children: [
>             'index.html',
>             'get-started',
>             'updating-firmware-(3.73)',
>             'installing-h-encore',
>             children: [
>              'uninstalling-cfw.md',
>               ],
>             'installing-enso',
>             'finalizing-setup'
>           ],
>         },
>       ],
> I have no idea if this'll work, but this is what I plan to do to fix this issue.

So I really don't know if this is how I do things, so @emiyl or @Plailect please make sure I don't like mega mess up the site, I'd rather not have that happen lol.

Thank you very much!!!!