### PR TITLE
A fix for 3.60 and below.

### DIFF
--- a/docs/.vuepress/configs/en_US.js
+++ b/docs/.vuepress/configs/en_US.js
@@ -78,7 +78,7 @@ module.exports = {
             'index.html',
             'get-started',
             'installing-henkaku',
-            'installing-enso',
+            'installing-enso-(3.60)',
             'finalizing-setup'
           ],
         },

--- a/docs/.vuepress/configs/en_US.js
+++ b/docs/.vuepress/configs/en_US.js
@@ -79,7 +79,7 @@ module.exports = {
             'get-started',
             'installing-henkaku',
             'installing-enso-(3.60)',
-            'finalizing-setup'
+            'finalizing-setup-(3.60)'
           ],
         },
       ],

--- a/docs/finalizing-setup-(3.60).md
+++ b/docs/finalizing-setup-(3.60).md
@@ -1,6 +1,6 @@
 ---
-title: "Finalizing Setup (Legacy)"
-sidebar: false
+title: "Finalizing Setup (3.60)"
+sidebar: true
 ---
 
 ### Required Reading

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -7,7 +7,7 @@ sidebar: false
 
 Different device versions will require different steps to achieve the end goal of Custom Firmware. This page will help you find where to start for your device.
 
-Select the appropriate page for your version from the chart below. Note that the "from" and "to" fields are inclusive. This means that, for example, the "from 1.03 to 3.63" row includes 1.03, 3.63, and all versions in-between.
+Select the appropriate page for your version from the chart below. Note that the "from" and "to" fields are inclusive. This means that, for example, the "from 1.03 to 3.59" row includes 1.03, 3.59, and all versions in-between.
 
 Your device version can be found under the System Information menu in the System category of the Settings application.
 
@@ -35,11 +35,10 @@ Before starting, Windows users should enable the option to show file extensions 
   <tbody>
     <tr>
       <td style="text-align: center; font-weight: bold;">1.03</td>
-      <!--<td style="text-align: center; font-weight: bold;">3.57</td>-->
-      <td style="text-align: center; font-weight: bold;">3.63</td>
-      <td style="text-align: center; font-weight: bold;"><a href="updating-firmware-(3.74)">Updating Firmware (3.74)</a></td>
+      <td style="text-align: center; font-weight: bold;">3.59</td>
+      <td style="text-align: center; font-weight: bold;"><a href="updating-firmware-(3.60)">Updating Firmware (3.60)</a></td>
     </tr>
-    <!--<tr>
+    <tr>
       <td style="text-align: center; font-weight: bold;">3.60</td>
       <td style="text-align: center; font-weight: bold;">3.60</td>
       <td style="text-align: center; font-weight: bold;"><a href="installing-henkaku">Installing HENkaku</a></td>
@@ -48,7 +47,7 @@ Before starting, Windows users should enable the option to show file extensions 
       <td style="text-align: center; font-weight: bold;">3.61</td>
       <td style="text-align: center; font-weight: bold;">3.63</td>
       <td style="text-align: center; font-weight: bold;"><a href="updating-firmware-(3.74)">Updating Firmware (3.74)</a></td>
-    </tr>-->
+    </tr>
     <tr>
       <td style="text-align: center; font-weight: bold;">3.65</td>
       <td style="text-align: center; font-weight: bold;">3.74</td>
@@ -56,7 +55,3 @@ Before starting, Windows users should enable the option to show file extensions 
     </tr>
   </tbody>
 </table>
-
-::: tip
-Firmware version 3.60 can be modified by using [HENkaku](installing-henkaku), however it’s recommended to update to 3.74 for a simplified installation.
-:::

--- a/docs/installing-enso-(3.60).md
+++ b/docs/installing-enso-(3.60).md
@@ -1,6 +1,6 @@
 ---
 title: "Installing Ensō (3.60)"
-sidebar: false
+sidebar: true
 ---
 
 ### Required Reading


### PR DESCRIPTION
This makes the guide use the old route for 3.60 and below as it works better there (it doesn't require users to update just to downgrade back afterwards and it prevents people from struggling with h-encore).
I haven't abandonned making an app to make installation for every version easier and faster than VitaDeploy, but until i get the time to work on it, this is the best option.