### PR TITLE
Update for the guide after initial feedback from users

### DIFF
--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -45,11 +45,11 @@ Before starting, Windows users should enable the option to show file extensions 
     </tr>
     <tr>
       <td style="text-align: center; font-weight: bold;">3.61</td>
-      <td style="text-align: center; font-weight: bold;">3.63</td>
+      <td style="text-align: center; font-weight: bold;">3.73</td>
       <td style="text-align: center; font-weight: bold;"><a href="updating-firmware-(3.74)">Updating Firmware (3.74)</a></td>
     </tr>
     <tr>
-      <td style="text-align: center; font-weight: bold;">3.65</td>
+      <td style="text-align: center; font-weight: bold;">3.74</td>
       <td style="text-align: center; font-weight: bold;">3.74</td>
       <td style="text-align: center; font-weight: bold;"><a href="using-henlo">Using HENlo</a></td>
     </tr>

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -45,6 +45,16 @@ Before starting, Windows users should enable the option to show file extensions 
     </tr>
     <tr>
       <td style="text-align: center; font-weight: bold;">3.61</td>
+      <td style="text-align: center; font-weight: bold;">3.63</td>
+      <td style="text-align: center; font-weight: bold;"><a href="updating-firmware-(3.74)">Updating Firmware (3.74)</a></td>
+    </tr>
+    <tr>
+      <td style="text-align: center; font-weight: bold;">3.65</td>
+      <td style="text-align: center; font-weight: bold;">3.65</td>
+      <td style="text-align: center; font-weight: bold;"><a href="using-henlo">Using HENlo</a></td>
+    </tr>
+    <tr>
+      <td style="text-align: center; font-weight: bold;">3.67</td>
       <td style="text-align: center; font-weight: bold;">3.73</td>
       <td style="text-align: center; font-weight: bold;"><a href="updating-firmware-(3.74)">Updating Firmware (3.74)</a></td>
     </tr>

--- a/docs/installing-henkaku.md
+++ b/docs/installing-henkaku.md
@@ -19,9 +19,6 @@ If you have a PS Vita 1000, you must also have an official Sony memory card (of 
 ### What You Need
 
 * An internet connection on your PS Vita (TV)
-* An FTP Client such as [WinSCP](https://winscp.net/) or [CyberDuck](https://cyberduck.io/)
-* The latest release of [VitaDeploy](https://github.com/SKGleba/VitaDeploy/releases/latest/)
-  + Download the `VitaDeploy.vpk` file
 
 ### Instructions
 
@@ -36,22 +33,8 @@ If you have a PS Vita 1000, you must also have an official Sony memory card (of 
 
 If you have VitaShell installed from a previous homebrew installation, HENkaku won't install molecularShell as it will detect a pre-existing taiHEN config. This will not be an issue.
 
-#### Section II - Installing VitaDeploy
 
-1. Launch the molecularShell application
-1. Press <Btn btn="SELECT" /> to enable FTP access on your device
-1. Open your FTP client on your computer
-1. Enter the IP Address and Port displayed on your device
-1. Using your FTP client, navigate to `ux0:` -> `data/`
-1. Transfer `VitaDeploy.vpk` to the `data` folder
-1. Press <Btn btn="cancel" /> on your device to close the FTP connection
-1. On your device, navigate to `ux0:` -> `data/`
-1. Press <Btn btn="confirm" /> on `VitaDeploy.vpk` to install it
-1. Press <Btn btn="confirm" /> again to confirm the install
-1. Press <Btn btn="confirm" /> once more to confirm again
-1. Close the molecularShell application
-
-#### Section III - Configuring HENkaku
+#### Section II - Configuring HENkaku
 
 1. Launch the Settings application
 1. Navigate to `HENkaku Settings`

--- a/docs/using-henlo.md
+++ b/docs/using-henlo.md
@@ -28,8 +28,10 @@ The "VitaDeploy" application will also be installed to your home screen. VitaDep
 
 1. Press <Btn btn="confirm" /> on "Install henkaku" to enable homebrew
 1. Press <Btn btn="confirm" /> on "Install VitaDeploy"
-    - If you are on a first generation Vita without a memory card, press <Btn btn="confirm" /> on "Replace NEAR with VitaDeploy" instead. Exit Henlo menu then use this opportunity to create an internal memory with vitadeploy following this [guide](https://guide.psp2.dev/guides/creating-an-internal-memory-card). You will need to run Henlo again and chose the install VitaDeploy option so that VitaDeploy is correctly installed on your internal memory.
+    - If you are on a first generation Vita without a memory card, press <Btn btn="confirm" /> on "Replace NEAR with VitaDeploy" instead
 1. Press <Btn btn="confirm" /> on "Exit"
+
+If you are on a first generation Vita without a memory card, we recommend you create an internal memory partition by following the [Creating an internal memory card](https://guide.psp2.dev/guides/creating-an-internal-memory-card). 
 
 #### Section III - Configuring HENkaku
 

--- a/docs/using-henlo.md
+++ b/docs/using-henlo.md
@@ -28,7 +28,7 @@ The "VitaDeploy" application will also be installed to your home screen. VitaDep
 
 1. Press <Btn btn="confirm" /> on "Install henkaku" to enable homebrew
 1. Press <Btn btn="confirm" /> on "Install VitaDeploy"
-    - If you are on a first generation Vita without a memory card, press <Btn btn="confirm" /> on "Replace NEAR with VitaDeploy" instead (requires a reboot and will reset LiveArea screen layout)
+    - If you are on a first generation Vita without a memory card, press <Btn btn="confirm" /> on "Replace NEAR with VitaDeploy" instead (requires a reboot and will reset LiveArea screen layout). After the reboot, launch Henlo again and simply use the exit option. Then use this opportunity to create an internal memory with vitadeploy following this [guide](https://guide.psp2.dev/guides/creating-an-internal-memory-card). You will need to run Henlo again and chose the install VitaDeploy option so that VitaDeploy is correctly installed on your internal memory.
 1. Press <Btn btn="confirm" /> on "Exit"
 
 #### Section III - Configuring HENkaku

--- a/docs/using-henlo.md
+++ b/docs/using-henlo.md
@@ -28,7 +28,7 @@ The "VitaDeploy" application will also be installed to your home screen. VitaDep
 
 1. Press <Btn btn="confirm" /> on "Install henkaku" to enable homebrew
 1. Press <Btn btn="confirm" /> on "Install VitaDeploy"
-    - If you are on a first generation Vita without a memory card, press <Btn btn="confirm" /> on "Replace NEAR with VitaDeploy" instead (requires a reboot and will reset LiveArea screen layout). After the reboot, launch Henlo again and simply use the exit option. Then use this opportunity to create an internal memory with vitadeploy following this [guide](https://guide.psp2.dev/guides/creating-an-internal-memory-card). You will need to run Henlo again and chose the install VitaDeploy option so that VitaDeploy is correctly installed on your internal memory.
+    - If you are on a first generation Vita without a memory card, press <Btn btn="confirm" /> on "Replace NEAR with VitaDeploy" instead. Exit Henlo menu then use this opportunity to create an internal memory with vitadeploy following this [guide](https://guide.psp2.dev/guides/creating-an-internal-memory-card). You will need to run Henlo again and chose the install VitaDeploy option so that VitaDeploy is correctly installed on your internal memory.
 1. Press <Btn btn="confirm" /> on "Exit"
 
 #### Section III - Configuring HENkaku


### PR DESCRIPTION
This PR fix 3 points :

1 The version table, Henlo exploit is supposed to work on all firmware, but Henlo Implementation by SKGleba only supports 3.65 and 3.74, if you try to run Henlo in between the user will meet this message "firmware unsupported". So they must update to 3.74

2 People without memorycard following this guide will have vitadeploy replacing near, the problem is that downgrading installs the 3.65 on top so vitadeploy is removed from system app. And if the user wants to try to run henlo again to get vitadeploy back it will have an error because of the PSVita version spoof that will trick Henlo into thinking it should use 3.74 ropchain on 3.65. Hence the fail. I have added more instructions to prevent the user from being lost at this point.

3 Removed vitadeploy install in 3.60 guide, installing the vpk serves no purpose as vitadeploy isn't used in the guide for 3.60

