### PR TITLE
Change of menu item label in VitaDeploy

### DIFF
--- a/docs/yamt.md
+++ b/docs/yamt.md
@@ -40,7 +40,7 @@ If you previously installed StorageMgr or another storage plugin, please remove 
 1. Press <Btn btn="confirm" /> on "Format target storage"
     + If this fails, ensure the adapter is inserted properly and is undamaged - then reboot and try again
     + If it still fails, follow the [StorageMgr](storagemgr) guide
-1. Navigate back to the Vita Deploy menu and press <Btn btn="confirm" /> on "Reboot your device"
+1. Navigate back to the Vita Deploy menu and press <Btn btn="confirm" /> on "Reboot"
 
 #### Section II - Installing yamt-vita
 


### PR DESCRIPTION
I just went through this guide on a new Vita and this menu item in VitaDeploy is now simply labelled "Reboot".