### PR TITLE
Guide 3.60 users to just update and use HENlo instead of henkaku.xyz

### DIFF
--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -7,7 +7,7 @@ sidebar: false
 
 Different device versions will require different steps to achieve the end goal of Custom Firmware. This page will help you find where to start for your device.
 
-Select the appropriate page for your version from the chart below. Note that the "from" and "to" fields are inclusive. This means that, for example, the "from 1.03 to 3.59" row includes 1.03, 3.59, and all versions in-between.
+Select the appropriate page for your version from the chart below. Note that the "from" and "to" fields are inclusive. This means that, for example, the "from 1.03 to 3.63" row includes 1.03, 3.63, and all versions in-between.
 
 Your device version can be found under the System Information menu in the System category of the Settings application.
 
@@ -33,16 +33,6 @@ Before starting, Windows users should enable the option to show file extensions 
     </tr>
   </thead>
   <tbody>
-    <tr>
-      <td style="text-align: center; font-weight: bold;">1.03</td>
-      <td style="text-align: center; font-weight: bold;">3.59</td>
-      <td style="text-align: center; font-weight: bold;"><a href="updating-firmware-(3.74).html">Updating Firmware (3.74)</a></td>
-    </tr>
-    <tr>
-      <td style="text-align: center; font-weight: bold;">3.60</td>
-      <td style="text-align: center; font-weight: bold;">3.60</td>
-      <td style="text-align: center; font-weight: bold;"><a href="installing-henkaku.html">Installing HENkaku</a></td>
-    </tr>
     <tr>
       <td style="text-align: center; font-weight: bold;">1.03</td>
       <td style="text-align: center; font-weight: bold;">3.63</td>


### PR DESCRIPTION
This is mainly because HENlo installs VitaDeploy, which lets you easily do "Quick 3.65 Install" with Enso and various plugins. Unless there's a 3.60 compatible exploit site that installs VitaDeploy, I personally feel this is the preferred path for new users that happen to have a console conviently on 3.60 compared to using henkaku.xyz and setting everything up manually with FTP.