### PR TITLE
Update site-navigation.md to have the link for the 3.60 finalization guide

### DIFF
--- a/docs/site-navigation.md
+++ b/docs/site-navigation.md
@@ -13,7 +13,7 @@ ads: false
 + [Downgrading Firmware (3.65)](downgrading-firmware-(3.65))
 + [FAQ](faq)
 + [File Extensions (Windows)](file-extensions-(windows))
-+ [Finalizing Setup (Legacy)](finalizing-setup-(legacy))
++ [Finalizing Setup (3.60)](finalizing-setup-(3.60))
 + [Finalizing Setup](finalizing-setup)
 + [Get Started](get-started)
 + [Home](index.html)


### PR DESCRIPTION
Must've been an oversight or something. Currently it's linking to a non-existant version of the page that had a previous name.