### PR TITLE
SKGLeba's HENlo supports 3.68 natively, so get-started.md now guides to HENlo for 3.68 FW

### DIFF
--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -35,7 +35,7 @@ Before starting, Windows users should enable the option to show file extensions 
   <tbody>
     <tr>
       <td style="text-align: center; font-weight: bold;">1.03</td>
-      <td style="text-align: center; font-weight: bold;">3.59</td>
+      <td style="text-align: center; font-weight: bold;">3.57</td>
       <td style="text-align: center; font-weight: bold;"><a href="updating-firmware-(3.74).html">Updating Firmware (3.74)</a></td>
     </tr>
     <tr>
@@ -44,13 +44,23 @@ Before starting, Windows users should enable the option to show file extensions 
       <td style="text-align: center; font-weight: bold;"><a href="installing-henkaku.html">Installing HENkaku</a></td>
     </tr>
     <tr>
-      <td style="text-align: center; font-weight: bold;">1.03</td>
+      <td style="text-align: center; font-weight: bold;">3.61</td>
       <td style="text-align: center; font-weight: bold;">3.63</td>
       <td style="text-align: center; font-weight: bold;"><a href="updating-firmware-(3.74).html">Updating Firmware (3.74)</a></td>
     </tr>
     <tr>
       <td style="text-align: center; font-weight: bold;">3.65</td>
       <td style="text-align: center; font-weight: bold;">3.65</td>
+      <td style="text-align: center; font-weight: bold;"><a href="using-henlo.html">Using HENlo</a></td>
+    </tr>
+    <tr>
+      <td style="text-align: center; font-weight: bold;">3.67</td>
+      <td style="text-align: center; font-weight: bold;">3.67</td>
+      <td style="text-align: center; font-weight: bold;"><a href="updating-firmware-(3.74).html">Updating Firmware (3.74)</a></td>
+    </tr>
+    <tr>
+      <td style="text-align: center; font-weight: bold;">3.68</td>
+      <td style="text-align: center; font-weight: bold;">3.68</td>
       <td style="text-align: center; font-weight: bold;"><a href="using-henlo.html">Using HENlo</a></td>
     </tr>
     <tr>

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -7,7 +7,7 @@ sidebar: false
 
 Different device versions will require different steps to achieve the end goal of Custom Firmware. This page will help you find where to start for your device.
 
-Select the appropriate page for your version from the chart below. Note that the "from" and "to" fields are inclusive. This means that, for example, the "from 1.03 to 3.59" row includes 1.03, 3.59, and all versions in-between.
+Select the appropriate page for your version from the chart below. Note that the "from" and "to" fields are inclusive. This means that, for example, the "from 1.03 to 3.57" row includes 1.03, 3.57, and all versions in-between.
 
 Your device version can be found under the System Information menu in the System category of the Settings application.
 

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -64,7 +64,7 @@ Before starting, Windows users should enable the option to show file extensions 
       <td style="text-align: center; font-weight: bold;"><a href="using-henlo.html">Using HENlo</a></td>
     </tr>
     <tr>
-      <td style="text-align: center; font-weight: bold;">3.67</td>
+      <td style="text-align: center; font-weight: bold;">3.69</td>
       <td style="text-align: center; font-weight: bold;">3.73</td>
       <td style="text-align: center; font-weight: bold;"><a href="updating-firmware-(3.74).html">Updating Firmware (3.74)</a></td>
     </tr>


### PR DESCRIPTION
Sauce: https://guide.psp2.dev/
The version table was also a bit confusing, so it has been clarified slightly.