### PR TITLE
navbar/sidebar cleanup

### DIFF
--- a/docs/.vitepress/i18n/en_US.js
+++ b/docs/.vitepress/i18n/en_US.js
@@ -49,7 +49,6 @@ const themeConfig = {
       {
         text: 'Guide',
         items: [
-          { text: 'Home', link: '/index.html' },
           { text: 'Get Started', link: '/get-started' },
           { text: 'Installing HENkaku', link: '/installing-henkaku' },
           { text: 'Installing Ensō (3.60)', link: '/installing-enso-(3.60)' },
@@ -61,7 +60,6 @@ const themeConfig = {
       {
         text: 'Guide',
         items: [
-          { text: 'Home', link: '/index.html' },
           { text: 'Get Started', link: '/get-started' },
           { text: 'Installing HENkaku', link: '/installing-henkaku' },
           { text: 'Installing Ensō (3.60)', link: '/installing-enso-(3.60)' },
@@ -73,7 +71,6 @@ const themeConfig = {
       {
         text: 'Guide',
         items: [
-          { text: 'Home', link: '/index.html' },
           { text: 'Get Started', link: '/get-started' },
           { text: 'Installing HENkaku', link: '/installing-henkaku' },
           { text: 'Installing Ensō (3.60)', link: '/installing-enso-(3.60)' },

--- a/docs/.vitepress/i18n/en_US.js
+++ b/docs/.vitepress/i18n/en_US.js
@@ -78,18 +78,6 @@ const themeConfig = {
         ],
       },
     ],
-    '/updating-firmware-(3.74)': [
-      {
-        text: 'Guide',
-        items: [
-          { text: 'Get Started', link: '/get-started' },
-          { text: 'Updating Firmware (3.74)', link: '/updating-firmware-(3.74)' },
-          { text: 'Using HENlo', link: '/using-henlo' },
-          { text: 'Installing Ensō', link: '/installing-enso' },
-          { text: 'Finalizing Setup', link: '/finalizing-setup' }
-        ],
-      },
-    ],
     '/': [
       {
         text: 'Guide',

--- a/docs/.vitepress/i18n/en_US.js
+++ b/docs/.vitepress/i18n/en_US.js
@@ -1,3 +1,22 @@
+const sidebar_guide_henkaku = {
+  text: 'Guide',
+  items: [
+    { text: 'Get Started', link: '/get-started' },
+    { text: 'Installing HENkaku', link: '/installing-henkaku' },
+    { text: 'Installing Ensō (3.60)', link: '/installing-enso-(3.60)' },
+    { text: 'Finalizing Setup (3.60)', link: '/finalizing-setup-(3.60)' }
+  ],
+}
+
+const sidebar_guide_henlo = {
+  text: 'Guide',
+  items: [
+    { text: 'Get Started', link: '/get-started' },
+    { text: 'Installing HENkaku', link: '/installing-henkaku' },
+    { text: 'Installing Ensō (3.60)', link: '/installing-enso-(3.60)' },
+    { text: 'Finalizing Setup (3.60)', link: '/finalizing-setup-(3.60)' }
+  ],
+}
 const themeConfig = {
   search: 'Search',
   selectLanguageName: "English",
@@ -46,49 +65,16 @@ const themeConfig = {
     
   sidebar: {
     '/installing-henkaku': [
-      {
-        text: 'Guide',
-        items: [
-          { text: 'Get Started', link: '/get-started' },
-          { text: 'Installing HENkaku', link: '/installing-henkaku' },
-          { text: 'Installing Ensō (3.60)', link: '/installing-enso-(3.60)' },
-          { text: 'Finalizing Setup (3.60)', link: '/finalizing-setup-(3.60)' }
-        ],
-      },
+      sidebar_guide_henkaku
     ],
     '/installing-enso-(3.60)': [
-      {
-        text: 'Guide',
-        items: [
-          { text: 'Get Started', link: '/get-started' },
-          { text: 'Installing HENkaku', link: '/installing-henkaku' },
-          { text: 'Installing Ensō (3.60)', link: '/installing-enso-(3.60)' },
-          { text: 'Finalizing Setup (3.60)', link: '/finalizing-setup-(3.60)' }
-        ],
-      },
+      sidebar_guide_henkaku
     ],
     '/finalizing-setup-(3.60)': [
-      {
-        text: 'Guide',
-        items: [
-          { text: 'Get Started', link: '/get-started' },
-          { text: 'Installing HENkaku', link: '/installing-henkaku' },
-          { text: 'Installing Ensō (3.60)', link: '/installing-enso-(3.60)' },
-          { text: 'Finalizing Setup (3.60)', link: '/finalizing-setup-(3.60)' }
-        ],
-      },
+      sidebar_guide_henkaku
     ],
     '/': [
-      {
-        text: 'Guide',
-        items: [
-          { text: 'Get Started', link: '/get-started' },
-          { text: 'Updating Firmware (3.74)', link: '/updating-firmware-(3.74)' },
-          { text: 'Using HENlo', link: '/using-henlo' },
-          { text: 'Installing Ensō', link: '/installing-enso' },
-          { text: 'Finalizing Setup', link: '/finalizing-setup' }
-        ],
-      },
+      sidebar_guide_henlo
     ],
   },
 };

--- a/docs/.vitepress/i18n/en_US.js
+++ b/docs/.vitepress/i18n/en_US.js
@@ -82,6 +82,7 @@ const themeConfig = {
       {
         text: 'Guide',
         items: [
+          { text: 'Get Started', link: '/get-started' },
           { text: 'Updating Firmware (3.74)', link: '/updating-firmware-(3.74)' },
           { text: 'Using HENlo', link: '/using-henlo' },
           { text: 'Installing Ensō', link: '/installing-enso' },
@@ -93,6 +94,7 @@ const themeConfig = {
       {
         text: 'Guide',
         items: [
+          { text: 'Get Started', link: '/get-started' },
           { text: 'Updating Firmware (3.74)', link: '/updating-firmware-(3.74)' },
           { text: 'Using HENlo', link: '/using-henlo' },
           { text: 'Installing Ensō', link: '/installing-enso' },

--- a/docs/.vitepress/i18n/en_US.js
+++ b/docs/.vitepress/i18n/en_US.js
@@ -31,11 +31,7 @@ const themeConfig = {
       text: 'Help',
       items: [
         { text: 'Troubleshooting', link: '/troubleshooting' },
-        { text: 'FAQ', link: '/faq' },
-        {
-          text: 'Discord',
-          link: 'https://discord.gg/m7MwpKA'
-        },
+        { text: 'FAQ', link: '/faq' }
       ]
     },
     {

--- a/docs/.vitepress/i18n/en_US.js
+++ b/docs/.vitepress/i18n/en_US.js
@@ -16,22 +16,22 @@ const themeConfig = {
     {
       text: 'Guides',
       items: [
-        { text: 'Adrenaline', link: 'adrenaline' },
+        { text: 'Adrenaline', link: '/adrenaline' },
         {
           text: 'SD2Vita',
-          link: 'yamt'
+          link: '/yamt'
         },
           {
           text: 'Uninstalling CFW',
-          link: 'uninstalling-cfw'
+          link: '/uninstalling-cfw'
         },
       ]
     },
     {
       text: 'Help',
       items: [
-        { text: 'Troubleshooting', link: 'troubleshooting' },
-        { text: 'FAQ', link: 'faq' },
+        { text: 'Troubleshooting', link: '/troubleshooting' },
+        { text: 'FAQ', link: '/faq' },
         {
           text: 'Discord',
           link: 'https://discord.gg/m7MwpKA'
@@ -41,9 +41,9 @@ const themeConfig = {
     {
       text: 'Site Info',
       items: [
-        { text: 'Donations', link: 'donations' },
-        { text: 'Credits', link: 'credits' },
-        { text: 'Site Navigation', link: 'site-navigation' }
+        { text: 'Donations', link: '/donations' },
+        { text: 'Credits', link: '/credits' },
+        { text: 'Site Navigation', link: '/site-navigation' }
       ]
     },
   ],
@@ -53,11 +53,11 @@ const themeConfig = {
       {
         text: 'Guide',
         items: [
-          { text: 'Home', link: 'index.html' },
-          { text: 'Get Started', link: 'get-started' },
-          { text: 'Installing HENkaku', link: 'installing-henkaku' },
-          { text: 'Installing Ensō (3.60)', link: 'installing-enso-(3.60)' },
-          { text: 'Finalizing Setup (3.60)', link: 'finalizing-setup-(3.60)' }
+          { text: 'Home', link: '/index.html' },
+          { text: 'Get Started', link: '/get-started' },
+          { text: 'Installing HENkaku', link: '/installing-henkaku' },
+          { text: 'Installing Ensō (3.60)', link: '/installing-enso-(3.60)' },
+          { text: 'Finalizing Setup (3.60)', link: '/finalizing-setup-(3.60)' }
         ],
       },
     ],
@@ -65,11 +65,11 @@ const themeConfig = {
       {
         text: 'Guide',
         items: [
-          { text: 'Home', link: 'index.html' },
-          { text: 'Get Started', link: 'get-started' },
-          { text: 'Installing HENkaku', link: 'installing-henkaku' },
-          { text: 'Installing Ensō (3.60)', link: 'installing-enso-(3.60)' },
-          { text: 'Finalizing Setup (3.60)', link: 'finalizing-setup-(3.60)' }
+          { text: 'Home', link: '/index.html' },
+          { text: 'Get Started', link: '/get-started' },
+          { text: 'Installing HENkaku', link: '/installing-henkaku' },
+          { text: 'Installing Ensō (3.60)', link: '/installing-enso-(3.60)' },
+          { text: 'Finalizing Setup (3.60)', link: '/finalizing-setup-(3.60)' }
         ],
       },
     ],
@@ -77,11 +77,11 @@ const themeConfig = {
       {
         text: 'Guide',
         items: [
-          { text: 'Home', link: 'index.html' },
-          { text: 'Get Started', link: 'get-started' },
-          { text: 'Installing HENkaku', link: 'installing-henkaku' },
-          { text: 'Installing Ensō (3.60)', link: 'installing-enso-(3.60)' },
-          { text: 'Finalizing Setup (3.60)', link: 'finalizing-setup-(3.60)' }
+          { text: 'Home', link: '/index.html' },
+          { text: 'Get Started', link: '/get-started' },
+          { text: 'Installing HENkaku', link: '/installing-henkaku' },
+          { text: 'Installing Ensō (3.60)', link: '/installing-enso-(3.60)' },
+          { text: 'Finalizing Setup (3.60)', link: '/finalizing-setup-(3.60)' }
         ],
       },
     ],
@@ -89,10 +89,10 @@ const themeConfig = {
       {
         text: 'Guide',
         items: [
-          { text: 'Updating Firmware (3.74)', link: 'updating-firmware-(3.74)' },
-          { text: 'Using HENlo', link:'using-henlo' },
-          { text: 'Installing Ensō', link: 'installing-enso' },
-          { text: 'Finalizing Setup', link: 'finalizing-setup' }
+          { text: 'Updating Firmware (3.74)', link: '/updating-firmware-(3.74)' },
+          { text: 'Using HENlo', link: '/using-henlo' },
+          { text: 'Installing Ensō', link: '/installing-enso' },
+          { text: 'Finalizing Setup', link: '/finalizing-setup' }
         ],
       },
     ],
@@ -100,10 +100,10 @@ const themeConfig = {
       {
         text: 'Guide',
         items: [
-          { text: 'Updating Firmware (3.74)', link: 'updating-firmware-(3.74)' },
-          { text: 'Using HENlo', link:'using-henlo' },
-          { text: 'Installing Ensō', link: 'installing-enso' },
-          { text: 'Finalizing Setup', link: 'finalizing-setup' }
+          { text: 'Updating Firmware (3.74)', link: '/updating-firmware-(3.74)' },
+          { text: 'Using HENlo', link: '/using-henlo' },
+          { text: 'Installing Ensō', link: '/installing-enso' },
+          { text: 'Finalizing Setup', link: '/finalizing-setup' }
         ],
       },
     ],

--- a/docs/installing-enso-(3.60).md
+++ b/docs/installing-enso-(3.60).md
@@ -1,3 +1,7 @@
+---
+next: true
+---
+
 # Installing Ensō (3.60)
 
 ### Required Reading

--- a/docs/installing-enso.md
+++ b/docs/installing-enso.md
@@ -1,3 +1,7 @@
+---
+next: true
+---
+
 # Installing Ensō
 
 ### Required Reading

--- a/docs/installing-henkaku.md
+++ b/docs/installing-henkaku.md
@@ -1,3 +1,7 @@
+---
+next: true
+---
+
 # Installing HENkaku
 
 ### Required Reading

--- a/docs/updating-firmware-(3.74).md
+++ b/docs/updating-firmware-(3.74).md
@@ -1,3 +1,7 @@
+---
+next: true
+---
+
 # Updating Firmware (3.74)
 
 ### Required Reading

--- a/docs/using-henlo.md
+++ b/docs/using-henlo.md
@@ -1,3 +1,7 @@
+---
+next: true
+---
+
 # Using HENlo
 
 ### Required Reading


### PR DESCRIPTION
- Fix navbar/sidebar highlights
    - These links need to be absolute paths.
- navbar: remove redundant Discord invite link
    - VitePress has its own icon for Discord invites, making this entry unnecessary.
- sidebar: remove index page
- sidebar: add get-started to all pages
- docs: add next button to select guide pages
    - All guide paths that exist in the sidebar now have a "next" button to navigate.
- sidebar: remove redundant firmware update specific sidebar
    - The default includes this page anyway.
- sidebar: commonize guide paths into its own objects
    - Copy pasting guide paths suck, and in most cases each page only has one path, so unify it this way.