### PR TITLE
Change regarding updating and formatting used vitas

### DIFF
--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -12,6 +12,10 @@ Select the appropriate page for your version from the chart below. Note that the
 
 Your device version can be found under the System Information menu in the System category of the Settings application.
 
+::: danger
+If you bought a second-hand PS Vita or you're unsure whether your console had CFW installed on it beforehand, before doing anything follow [Restoring System](restoring-system) to restore and format your console.
+:::
+
 ::: tip
 Before starting, Windows users should enable the option to show file extensions using [File Extensions (Windows)](file-extensions-(windows))!
 :::
@@ -36,36 +40,6 @@ Before starting, Windows users should enable the option to show file extensions 
   <tbody>
     <tr>
       <td style="text-align: center; font-weight: bold;">1.03</td>
-      <td style="text-align: center; font-weight: bold;">3.57</td>
-      <td style="text-align: center; font-weight: bold;"><a href="updating-firmware-(3.74).html">Updating Firmware (3.74)</a></td>
-    </tr>
-    <tr>
-      <td style="text-align: center; font-weight: bold;">3.60</td>
-      <td style="text-align: center; font-weight: bold;">3.60</td>
-      <td style="text-align: center; font-weight: bold;"><a href="installing-henkaku.html">Installing HENkaku</a></td>
-    </tr>
-    <tr>
-      <td style="text-align: center; font-weight: bold;">3.61</td>
-      <td style="text-align: center; font-weight: bold;">3.63</td>
-      <td style="text-align: center; font-weight: bold;"><a href="updating-firmware-(3.74).html">Updating Firmware (3.74)</a></td>
-    </tr>
-    <tr>
-      <td style="text-align: center; font-weight: bold;">3.65</td>
-      <td style="text-align: center; font-weight: bold;">3.65</td>
-      <td style="text-align: center; font-weight: bold;"><a href="using-henlo.html">Using HENlo</a></td>
-    </tr>
-    <tr>
-      <td style="text-align: center; font-weight: bold;">3.67</td>
-      <td style="text-align: center; font-weight: bold;">3.67</td>
-      <td style="text-align: center; font-weight: bold;"><a href="updating-firmware-(3.74).html">Updating Firmware (3.74)</a></td>
-    </tr>
-    <tr>
-      <td style="text-align: center; font-weight: bold;">3.68</td>
-      <td style="text-align: center; font-weight: bold;">3.68</td>
-      <td style="text-align: center; font-weight: bold;"><a href="using-henlo.html">Using HENlo</a></td>
-    </tr>
-    <tr>
-      <td style="text-align: center; font-weight: bold;">3.69</td>
       <td style="text-align: center; font-weight: bold;">3.73</td>
       <td style="text-align: center; font-weight: bold;"><a href="updating-firmware-(3.74).html">Updating Firmware (3.74)</a></td>
     </tr>

--- a/docs/restoring-system.md
+++ b/docs/restoring-system.md
@@ -1,0 +1,21 @@
+# Restoring System
+
+### Required Reading
+
+This is a section for users who bought a second-hand PS Vita or are unsure whether their console has had CFW installed on it before.
+
+### Instructions
+
+#### Section I - Restoring your PS VITA
+
+1. Open the Settings application
+1. Navigate to `Format` -> `Restore This System`
+1. Press <Btn btn="confirm" /> on "Restore"
+1. When prompted, select "Yes" to confirm 3 times
+1. Select "Format" and "Yes"
+1. Once formatted, select "OK" to reboot
+1. Do the initial setup
+
+::: tip
+Now, you can return to [Getting Started](get-started) and follow the guide like normal.
+:::


### PR DESCRIPTION
As discussed in discord
Restore system for used vitas etc. avoiding conflicts with old plugins
For every firmware except 3.74 update because it's the easiest and shortest way and if you install enso on firmware with enso installed you get brick
should be ready to merge