### PR TITLE
Remove mentions of h-encore in updating FW tutorial

### DIFF
--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -8,7 +8,7 @@ sidebar: false
 
 Different device versions will require different steps to achieve the end goal of Custom Firmware. This page will help you find where to start for your device.
 
-Select the appropriate page for your version from the chart below. Note that the "from" and "to" fields are inclusive. This means that, for example, the "from 1.03 to 3.57" row includes 1.03, 3.57, and all versions in-between.
+Select the appropriate page for your version from the chart below. Note that the "from" and "to" fields are inclusive. This means that, for example, the "from 1.03 to 3.73" row includes 1.03, 3.73, and all versions in-between.
 
 Your device version can be found under the System Information menu in the System category of the Settings application.
 

--- a/docs/updating-firmware-(3.74).md
+++ b/docs/updating-firmware-(3.74).md
@@ -6,7 +6,7 @@ next: true
 
 ### Required Reading
 
-The h-encore exploit is only compatible with the firmware versions 3.65 and above. As a result, lower firmware versions must update to the latest firmware to use the exploit.
+The HENlo exploit is only compatible with the firmware versions 3.65, 3,68, and 3.74. As a result, lower firmware versions must update to the latest firmware to use the exploit. Updating the firmware is also required to uninstall any previous installation of CFW on a used system.
 
 ### What you need
 

--- a/docs/updating-firmware-(3.74).md
+++ b/docs/updating-firmware-(3.74).md
@@ -6,7 +6,7 @@ next: true
 
 ### Required Reading
 
-The HENlo exploit is only compatible with the firmware versions 3.65, 3,68, and 3.74. As a result, lower firmware versions must update to the latest firmware to use the exploit. Updating the firmware is also required to uninstall any previous installation of CFW on a used system.
+The HENlo exploit is only compatible with the firmware versions 3.65, 3,68, and 3.74. As a result, lower firmware versions must update to the latest firmware to use the exploit. Updating the firmware is also the easiest method of uninstalling any previous installation of CFW on a used system.
 
 ### What you need
 


### PR DESCRIPTION
It ain't like 99% of people are gonna use h-encore these days anyway, and the guide doesn't need to have any mention of it whatsoever. An extra note is also added to indicate it's needed to remove previous Enso installations as well.