### PR TITLE
Minor edits

### DIFF
--- a/docs/updating-firmware-(3.74).md
+++ b/docs/updating-firmware-(3.74).md
@@ -6,7 +6,7 @@ next: true
 
 ### Required Reading
 
-The HENlo exploit is only compatible with the firmware versions 3.65, 3,68, and 3.74. As a result, lower firmware versions must update to the latest firmware to use the exploit. Updating the firmware is also the easiest method of uninstalling any previous installation of CFW on a used system.
+The HENlo exploit is only compatible with the firmware versions 3.65, 3.68, and 3.74. As a result, lower firmware versions must update to the latest firmware to use the exploit. Updating the firmware is also the easiest method of uninstalling any previous installation of CFW on a used system.
 
 ### What you need
 

--- a/docs/using-henlo.md
+++ b/docs/using-henlo.md
@@ -6,7 +6,7 @@ next: true
 
 ### Required Reading
 
-The HENlo exploit chain for the PS Vita (TV) allows for the installation of homebrew applications to the LiveArea Screen. It is compatible with the firmware versions 3.65 to 3.74.
+The HENlo exploit chain for the PS Vita (TV) allows for the installation of homebrew applications to the LiveArea Screen. It is compatible with the firmware versions 3.65, 3.68, and 3.74.
 
 Note that the HENlo chain is not "persistent" (meaning it does not remain installed after a reboot). Fortunately, this is only a temporary restriction until HENkaku Ensō is installed on the next page.
 


### PR DESCRIPTION
There is a typo in the Updating Firmware (3.74) page where "3.68" is misspelled with a comma instead of a period.

The firmware list on the Using Henlo page has also been updated to match the Updating Firmware page.