### PR TITLE
Update storage-format-(linux).md for kernel 5.7+ users

### DIFF
--- a/docs/storage-format-(linux).md
+++ b/docs/storage-format-(linux).md
@@ -14,9 +14,10 @@ This page is for Linux users only. If you are not on Linux, check out the [Stora
 
 ### What You Need
 
-* The latest version of [exfat-utils](https://github.com/relan/exfat) for your distribution (check your package manager)
-* The latest version of [fuse-exfat](https://github.com/relan/exfat) for your distribution (check your package manager)
-* The latest version of [F3](https://github.com/AltraMayor/f3/releases/latest)
+* For Kernel 5.7 and above: install [exfatprogs](https://github.com/exfatprogs/exfatprogs) for your distribution (check your package manager)
+* For Kernel 5.6 and below: install [fuse-exfat](https://github.com/relan/exfat) and [exfat-utils](https://github.com/relan/exfat) for your distribution (check your package manager)
+    + `fuse-exfat` package may named as `exfat-fuse` in some distribution
+* The latest version of [f3](https://github.com/AltraMayor/f3/) for your distribution (check your package manager)
     + This is not required if you do not want to check your storage device for errors
 
 ### Instructions
@@ -25,27 +26,23 @@ This page is for Linux users only. If you are not on Linux, check out the [Stora
 
 1. Insert your storage device into your computer
 1. Unmount your storage device with `umount`
-1. Run `sudo dd if=/dev/zero of=/dev/sdX` to wipe the storage device
-    + `sdX` should be the device corresponding to your storage device
-1. Remove your storage device from your computer
-1. Re-insert your storage device into your computer
 1. Run `mkfs.exfat /dev/sdX` to format your storage device as exFAT
+    + `sdX` should be the device corresponding to your storage device (don't point to existed partition, for example `sdX1`)
     + If your storage device has a capacity of 256 GB or greater, you must format with a cluster size of 64 KB
+        + For Kernel 5.7 and above: `mkfs.exfat /dev/sdX -c 64K`
+        + For Kernel 5.6 and below: `mkfs.exfat /dev/sdX -s 128K`
 
 #### Section II - Verifying Storage Device
 
 If you do not want to check your storage device for errors, skip this section.
 
-1. Unzip the f3 `.zip` file
-1. `cd` into the f3 directory
-1. Run `make` to compile F3
 1. Insert your storage device into your computer
 1. Mount your storage device
-1. Run `./f3write <your storage device mount point>`
+1. Run `f3write <your storage device mount point>`
 1. Wait until the process is complete. See below for an example output.
 
 ~~~ bash
-$ ./f3write /media/michel/6135-3363/
+$ f3write /media/michel/6135-3363/
 Free space: 29.71 GB
 Creating file 1.h2w ... OK!
 ...
@@ -54,21 +51,21 @@ Free space: 0.00 Byte
 Average Writing speed: 4.90 MB/s
 ~~~
 
-8. Run `./f3read <your storage device mount point>`
+5. Run `f3read <your storage device mount point>`
 1. Wait until the process is complete. See below for an example output.
 
 ~~~ bash
-$ ./f3read /media/michel/6135-3363/
-									SECTORS      ok/corrupted/changed/overwritten
+$ f3read /media/michel/6135-3363/
+                  SECTORS      ok/corrupted/changed/overwritten
 Validating file 1.h2w ... 2097152/        0/      0/      0
 ...
 Validating file 30.h2w ... 1491904/        0/      0/      0
 
-	Data OK: 29.71 GB (62309312 sectors)
+  Data OK: 29.71 GB (62309312 sectors)
 Data LOST: 0.00 Byte (0 sectors)
-					Corrupted: 0.00 Byte (0 sectors)
-	Slightly changed: 0.00 Byte (0 sectors)
-				Overwritten: 0.00 Byte (0 sectors)
+               Corrupted: 0.00 Byte (0 sectors)
+        Slightly changed: 0.00 Byte (0 sectors)
+             Overwritten: 0.00 Byte (0 sectors)
 Average Reading speed: 9.42 MB/s
 ~~~
 


### PR DESCRIPTION
Kernel 5.7 got native exFAT support and new tools to manage it, `exfatprogs`
Also did some testing and `dd` is not required, `mkfs.exfat` (both `exfatprogs` and `exfat-utils`) wipe all partitions and make correct exFAT fs on the sdcard if you point `mkfs.exfat` to a physical device (tested on Ubuntu 24.04 and 18.04.6)
 
And note about `-s 128K` for `exfat-utils`, idk why its format with double less cluster size (i only have 32gb sdcard and 64gb usb drive, so i cant test it with larger one), thats why is 128KB